### PR TITLE
検定詳細ページの実装

### DIFF
--- a/app/controllers/api/check_items_controller.rb
+++ b/app/controllers/api/check_items_controller.rb
@@ -1,0 +1,6 @@
+class Api::CheckItemsController < ApplicationController
+  def index
+    @check_items = CheckItem.all
+    render json: @check_items
+  end
+end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,3 @@
 class HomeController < ApplicationController
-  def index
-  end
+  def index; end
 end

--- a/app/javascript/components/TheHeader.vue
+++ b/app/javascript/components/TheHeader.vue
@@ -1,7 +1,12 @@
 <template>
   <header>
     <nav class="navbar navbar-expand navbar-dark bg-dark justify-content-between">
-      <router-link :to="{ name: 'TopIndex' }" class="navbar-brand mb-0 h1">{{ title }}</router-link> 
+      <router-link
+        :to="{ name: 'TopIndex' }"
+        class="navbar-brand mb-0 h1"
+      >
+        {{ title }}
+      </router-link> 
     </nav>
   </header>
 </template>

--- a/app/javascript/packs/hello_vue.js
+++ b/app/javascript/packs/hello_vue.js
@@ -4,12 +4,14 @@ import axios from '../plugins/axios'
 import 'bootstrap/dist/css/bootstrap.css'
 import 'bootstrap-vue/dist/bootstrap-vue.css'
 import router from './router.js'
+import store from '../store/store.js'
 
 Vue.config.productionTip = false
 Vue.prototype.$axios = axios
 
 document.addEventListener('DOMContentLoaded', () => {
 	const app = new Vue({
+    store,
     router,
     render: h => h(App)
   }).$mount()

--- a/app/javascript/packs/router.js
+++ b/app/javascript/packs/router.js
@@ -2,6 +2,7 @@ import Vue from 'vue'
 import VueRouter from 'vue-router'
 import TopIndex from '../pages/top/index.vue'
 import ExamListIndex from '../pages/exam_list/index.vue'
+import ExamIndex from '../pages/exam/index.vue'
 
 Vue.use(VueRouter)
 
@@ -17,6 +18,11 @@ export default new VueRouter({
       path: '/exams',
       name: 'ExamListIndex',
       component: ExamListIndex
+    },
+    {
+      path: '/exam/:exam_path',
+      name: 'ExamIndex',
+      component: ExamIndex
     }
   ]
 })

--- a/app/javascript/pages/exam/index.vue
+++ b/app/javascript/pages/exam/index.vue
@@ -1,9 +1,38 @@
 <template>
-  <div class="py-4 container">
-    <div class="text-center">
+  <div class="container">
+
+    <div class="mt-4">
       <h2>{{ selectedExam.title }}検定</h2>
+      <img class="img-fluid border" :src="getImagePath(selectedExam.title)" />
+      <p>{{ selectedExam.description }}</p>
     </div>
- 
+
+    <div v-for="(check_item, index) in selectedExamCheckItems" :key="check_item.id">
+      <div class="border py-1 my-2" >
+        <div class="pl-2 py-1">
+          Point: {{ index + 1 }} {{ check_item.content }}
+        </div>
+      </div>
+    </div>
+
+    <div class="form-group mt-4">
+      <label for="jojo-pose-image" class="d-block">ジョジョ立ち画像を添付</label>
+      <input
+        id="jojo-pose-image"
+        type="file"
+        class="form-control-file"
+      >
+      <div class="text-center my-4">
+        <button
+          type="submit"
+          class="btn btn-secondary"
+          @click="takeExam()"
+        >
+        受検するッ！
+        </button>
+      </div>
+    </div>
+
   </div>
 </template>
 
@@ -11,12 +40,34 @@
 import { mapGetters, mapActions, mapMutations } from 'vuex'
 
 export default {
+  created(){
+    this.getCheckItems()
+  },
   data: function () {
     return {
+      check_items: []
     }
   },
   computed: {
-    ...mapGetters('exams', ['selectedExam'])
+    ...mapGetters('exams', ['selectedExam']),
+    selectedExamCheckItems(){
+      return this.check_items.filter( check_item => check_item.exam_id === this.selectedExam.id )
+    }
+  },
+  methods: {
+    getCheckItems(){
+      this.$axios.get('/api/check_items')
+        .then(res => {
+          this.check_items = res.data
+        })
+        .catch(err => console.log(err.status))
+    },
+    getImagePath(title){
+      return require(`../../../assets/images/${title}.png`)
+    },
+    takeExam(){
+      console.log("受検ッ")
+    }
   }
 
 }

--- a/app/javascript/pages/exam/index.vue
+++ b/app/javascript/pages/exam/index.vue
@@ -1,0 +1,27 @@
+<template>
+  <div class="py-4 container">
+    <div class="text-center">
+      <h2>{{ selectedExam.title }}検定</h2>
+    </div>
+ 
+  </div>
+</template>
+
+<script>
+import { mapGetters, mapActions, mapMutations } from 'vuex'
+
+export default {
+  data: function () {
+    return {
+    }
+  },
+  computed: {
+    ...mapGetters('exams', ['selectedExam'])
+  }
+
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/app/javascript/pages/exam/index.vue
+++ b/app/javascript/pages/exam/index.vue
@@ -1,14 +1,19 @@
 <template>
   <div class="container">
-
     <div class="mt-4">
       <h2>{{ selectedExam.title }}検定</h2>
-      <img class="img-fluid border" :src="getImagePath(selectedExam.title)" />
+      <img
+        class="img-fluid border"
+        :src="getImagePath(selectedExam.title)"
+      >
       <p>{{ selectedExam.description }}</p>
     </div>
 
-    <div v-for="(check_item, index) in selectedExamCheckItems" :key="check_item.id">
-      <div class="border py-1 my-2" >
+    <div
+      v-for="(check_item, index) in selectedExamCheckItems"
+      :key="check_item.id"
+    >
+      <div class="border py-1 my-2">
         <div class="pl-2 py-1">
           Point: {{ index + 1 }} {{ check_item.content }}
         </div>
@@ -16,7 +21,10 @@
     </div>
 
     <div class="form-group mt-4">
-      <label for="jojo-pose-image" class="d-block">ジョジョ立ち画像を添付</label>
+      <label
+        for="jojo-pose-image"
+        class="d-block"
+      >ジョジョ立ち画像を添付</label>
       <input
         id="jojo-pose-image"
         type="file"
@@ -28,11 +36,10 @@
           class="btn btn-secondary"
           @click="takeExam()"
         >
-        受検するッ！
+          受検するッ！
         </button>
       </div>
     </div>
-
   </div>
 </template>
 
@@ -40,9 +47,6 @@
 import { mapGetters, mapActions, mapMutations } from 'vuex'
 
 export default {
-  created(){
-    this.getCheckItems()
-  },
   data: function () {
     return {
       check_items: []
@@ -53,6 +57,9 @@ export default {
     selectedExamCheckItems(){
       return this.check_items.filter( check_item => check_item.exam_id === this.selectedExam.id )
     }
+  },
+  created(){
+    this.getCheckItems()
   },
   methods: {
     getCheckItems(){

--- a/app/javascript/pages/exam_list/index.vue
+++ b/app/javascript/pages/exam_list/index.vue
@@ -5,9 +5,11 @@
     </div>
     <div class="row">
       <div class="mx-auto">
-       <div v-for="exam in exams" :key="exam.id" class="col-12 my-5">
-          <h5>{{ exam.title }}検定</h5>
-          <img class="img-fluid border" :src="getImagePath(exam.title)" />
+        <div v-for="exam in exams" :key="exam.id" class="col-12 my-5">
+          <router-link :to="{ name: 'ExamIndex', params: { exam_path: exam.path } }" @click.native="setSelectedExam(exam)" >
+            <h5>{{ exam.title }}検定</h5>
+            <img class="img-fluid border" :src="getImagePath(exam.title)" />
+          </router-link>
         </div>
       </div>
     </div>
@@ -16,7 +18,7 @@
 </template>
 
 <script>
-import { mapGetters, mapActions } from 'vuex'
+import { mapGetters, mapActions, mapMutations } from 'vuex'
 
 export default {
   created() {
@@ -30,11 +32,13 @@ export default {
     ...mapGetters('exams', ['exams'])
   },
   methods: {
+    ...mapMutations('exams', ['setSelectedExam']),
     ...mapActions('exams', ['fetchExams']),
 
     getImagePath(title){
       return require(`../../../assets/images/${title}.png`)
     }
+
   }
 }
 </script>

--- a/app/javascript/pages/exam_list/index.vue
+++ b/app/javascript/pages/exam_list/index.vue
@@ -16,22 +16,22 @@
 </template>
 
 <script>
+import { mapGetters, mapActions } from 'vuex'
 
 export default {
   created() {
-    this.getTasks()
+    this.fetchExams()
   },
   data: function () {
     return {
-      exams: []
     }
   },
+  computed:{
+    ...mapGetters('exams', ['exams'])
+  },
   methods: {
-    getTasks(){
-      this.$axios.get('exams')
-        .then(res => this.exams = res.data)
-        .catch(err => console.log(err.status))
-    },
+    ...mapActions('exams', ['fetchExams']),
+
     getImagePath(title){
       return require(`../../../assets/images/${title}.png`)
     }

--- a/app/javascript/pages/exam_list/index.vue
+++ b/app/javascript/pages/exam_list/index.vue
@@ -5,15 +5,24 @@
     </div>
     <div class="row">
       <div class="mx-auto">
-        <div v-for="exam in exams" :key="exam.id" class="col-12 my-5">
-          <router-link :to="{ name: 'ExamIndex', params: { exam_path: exam.path } }" @click.native="setSelectedExam(exam)" >
+        <div
+          v-for="exam in exams"
+          :key="exam.id"
+          class="col-12 my-5"
+        >
+          <router-link
+            :to="{ name: 'ExamIndex', params: { exam_path: exam.path } }"
+            @click.native="setSelectedExam(exam)"
+          >
             <h5>{{ exam.title }}検定</h5>
-            <img class="img-fluid border" :src="getImagePath(exam.title)" />
+            <img
+              class="img-fluid border"
+              :src="getImagePath(exam.title)"
+            >
           </router-link>
         </div>
       </div>
     </div>
-
   </div>
 </template>
 
@@ -21,15 +30,15 @@
 import { mapGetters, mapActions, mapMutations } from 'vuex'
 
 export default {
-  created() {
-    this.fetchExams()
-  },
   data: function () {
     return {
     }
   },
   computed:{
     ...mapGetters('exams', ['exams'])
+  },
+  created() {
+    this.fetchExams()
   },
   methods: {
     ...mapMutations('exams', ['setSelectedExam']),

--- a/app/javascript/pages/top/index.vue
+++ b/app/javascript/pages/top/index.vue
@@ -3,8 +3,15 @@
     <section class="py-4 text-center container">
       <div class="row">
         <div class="mx-auto">
-          <h2 class="fw-light">ジョジョ立ち検定</h2>
-          <router-link :to="{ name: 'ExamListIndex' }" class="btn btn-secondary">検定一覧へ</router-link> 
+          <h2 class="fw-light">
+            ジョジョ立ち検定
+          </h2>
+          <router-link
+            :to="{ name: 'ExamListIndex' }"
+            class="btn btn-secondary"
+          >
+            検定一覧へ
+          </router-link> 
         </div>
       </div>
     </section>

--- a/app/javascript/plugins/axios.js
+++ b/app/javascript/plugins/axios.js
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 const axiosInstance = axios.create({
-  baseURL: 'api'
+  // baseURL: 'api'
 })
 
 export default axiosInstance

--- a/app/javascript/store/modules/exams.js
+++ b/app/javascript/store/modules/exams.js
@@ -4,18 +4,25 @@ export default {
   namespaced: true,
 
   state: {
-    exams: []
+    exams: [],
+    selectedExam: {}
   },
 
   getters: {
     exams(state){
       return state.exams
+    },
+    selectedExam(state){
+      return state.selectedExam
     }
   },
 
   mutations: {
     setExams(state, exams){
       state.exams = exams
+    },
+    setSelectedExam(state, exam){
+      state.selectedExam = exam
     }
   },
 

--- a/app/javascript/store/modules/exams.js
+++ b/app/javascript/store/modules/exams.js
@@ -28,7 +28,7 @@ export default {
 
   actions: {
     fetchExams({commit}){
-      axios.get('exams')
+      axios.get('/api/exams')
         .then(res => commit('setExams', res.data))
         .catch(err => console.log(err.response))
     }

--- a/app/javascript/store/modules/exams.js
+++ b/app/javascript/store/modules/exams.js
@@ -1,0 +1,29 @@
+import axios from '../../plugins/axios'
+
+export default {
+  namespaced: true,
+
+  state: {
+    exams: []
+  },
+
+  getters: {
+    exams(state){
+      return state.exams
+    }
+  },
+
+  mutations: {
+    setExams(state, exams){
+      state.exams = exams
+    }
+  },
+
+  actions: {
+    fetchExams({commit}){
+      axios.get('exams')
+        .then(res => commit('setExams', res.data))
+        .catch(err => console.log(err.response))
+    }
+  }
+}

--- a/app/javascript/store/store.js
+++ b/app/javascript/store/store.js
@@ -1,5 +1,6 @@
 import Vue from 'vue'
 import Vuex from 'vuex'
+import createPersistedState from 'vuex-persistedstate'
 import ExamsModule from './modules/exams'
 
 Vue.use(Vuex)
@@ -7,5 +8,14 @@ Vue.use(Vuex)
 export default new Vuex.Store({
   modules: {
     exams: ExamsModule
-  }
+  },
+  plugins: [createPersistedState(
+    {
+      key: 'jojoPoseExam',
+      paths:[
+        'exams.selectedExam'
+      ],
+      storage: window.localStorage
+    }
+  )]
 })

--- a/app/javascript/store/store.js
+++ b/app/javascript/store/store.js
@@ -1,0 +1,11 @@
+import Vue from 'vue'
+import Vuex from 'vuex'
+import ExamsModule from './modules/exams'
+
+Vue.use(Vuex)
+
+export default new Vuex.Store({
+  modules: {
+    exams: ExamsModule
+  }
+})

--- a/app/models/check_item.rb
+++ b/app/models/check_item.rb
@@ -1,0 +1,9 @@
+class CheckItem < ApplicationRecord
+  belongs_to :exam
+
+  validates :exam, presence: true
+  validates :content, presence: true
+  validates :allocation, presence: true
+  validates :check_pattern, presence: true
+
+end

--- a/app/models/check_item.rb
+++ b/app/models/check_item.rb
@@ -5,5 +5,4 @@ class CheckItem < ApplicationRecord
   validates :content, presence: true
   validates :allocation, presence: true
   validates :check_pattern, presence: true
-
 end

--- a/app/models/exam.rb
+++ b/app/models/exam.rb
@@ -1,5 +1,5 @@
 class Exam < ApplicationRecord
-  has_many :check_items
+  has_many :check_items, dependent: :destroy
 
   validates :title, presence: true
   validates :path, presence: true

--- a/app/models/exam.rb
+++ b/app/models/exam.rb
@@ -1,3 +1,4 @@
 class Exam < ApplicationRecord
   validates :title, presence: true
+  validates :path, presence: true
 end

--- a/app/models/exam.rb
+++ b/app/models/exam.rb
@@ -1,4 +1,6 @@
 class Exam < ApplicationRecord
+  has_many :check_items
+
   validates :title, presence: true
   validates :path, presence: true
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,7 +36,7 @@ module JojoPoseExam
     config.generators.system_tests = nil
 
     config.generators do |g|
-      g.assets false 
+      g.assets false
       g.helper false
       g.skip_routes true
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
 
   namespace :api, format: 'json' do
     resources :exams, only: %i[index]
+    resources :check_items, only: %i[index]
   end
 
   get '*path', to: 'home#index'

--- a/db/migrate/20211205083323_add_path_to_exams.rb
+++ b/db/migrate/20211205083323_add_path_to_exams.rb
@@ -1,0 +1,5 @@
+class AddPathToExams < ActiveRecord::Migration[6.1]
+  def change
+    add_column :exams, :path, :string, null: false
+  end
+end

--- a/db/migrate/20211205143021_create_check_items.rb
+++ b/db/migrate/20211205143021_create_check_items.rb
@@ -1,0 +1,12 @@
+class CreateCheckItems < ActiveRecord::Migration[6.1]
+  def change
+    create_table :check_items do |t|
+      t.belongs_to :exam, null: false
+      t.string :content, null: false
+      t.integer :allocation, null: false
+      t.integer :check_pattern, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_30_125929) do
+ActiveRecord::Schema.define(version: 2021_12_05_083323) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2021_11_30_125929) do
     t.string "description"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "path", null: false
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_05_083323) do
+ActiveRecord::Schema.define(version: 2021_12_05_143021) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "check_items", force: :cascade do |t|
+    t.bigint "exam_id", null: false
+    t.string "content", null: false
+    t.integer "allocation", null: false
+    t.integer "check_pattern", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["exam_id"], name: "index_check_items_on_exam_id"
+  end
 
   create_table "exams", force: :cascade do |t|
     t.string "title", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,45 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+giorno_exam = Exam.new(
+  title: "ジョルノ立ち",
+  description: "第5部「黄金の風」の第5話「ブチャラティが来る② 」にて、主人公のジョルノ・ジョバーナが行ったジョジョ立ち。ジョルノの回想シーン中で「ギャング・スター」にあこがれるようになったのだ！というナレーションと共に描かれた。",
+  path: "giorno"
+)
+giorno_exam.save!
+
+CheckItem.create!([
+  {
+    exam: giorno_exam,
+    check_pattern: 1,
+    content: "顎を軽く引き、正面を見据える",
+    allocation: 10
+  },
+  {
+    exam: giorno_exam,
+    check_pattern: 2,
+    content: "右肘を曲げ、右手で胸元を掴む",
+    allocation: 20
+  },
+  {
+    exam: giorno_exam,
+    check_pattern: 3,
+    content: "左手を軽く握り、左腿に添える",
+    allocation: 20
+  },
+  {
+    exam: giorno_exam,
+    check_pattern: 4,
+    content: "股を大きく開く",
+    allocation: 10
+  },
+  {
+    exam: giorno_exam,
+    check_pattern: 5,
+    content: "右膝を真っ直ぐ斜めに伸ばす",
+    allocation: 20
+  },
+  {
+    exam: giorno_exam,
+    check_pattern: 6,
+    content: "左膝を軽く曲げ、踵を浮かす",
+    allocation: 20
+  }
+])

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "vue-router": "^3.5.3",
     "vue-template-compiler": "^2.6.14",
     "vuex": "^3.6.2",
+    "vuex-persistedstate": "^4.1.0",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12"
   },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "vue-loader": "^15.9.8",
     "vue-router": "^3.5.3",
     "vue-template-compiler": "^2.6.14",
+    "vuex": "^3.6.2",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12"
   },

--- a/spec/factories/check_items.rb
+++ b/spec/factories/check_items.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :check_item do
+    exam { nil }
+    cntent { "MyString" }
+    allocation { "" }
+    check_pattern { "" }
+  end
+end

--- a/spec/models/check_item_spec.rb
+++ b/spec/models/check_item_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe CheckItem, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -7317,6 +7317,11 @@ vue@^2.6.14:
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.14.tgz#e51aa5250250d569a3fbad3a8a5a687d6036e235"
   integrity sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ==
 
+vuex@^3.6.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/vuex/-/vuex-3.6.2.tgz#236bc086a870c3ae79946f107f16de59d5895e71"
+  integrity sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==
+
 watchpack-chokidar2@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/watchpack-chokidar2/-/watchpack-chokidar2-2.0.1.tgz#38500072ee6ece66f3769936950ea1771be1c957"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2500,6 +2500,11 @@ deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
+deepmerge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+
 default-gateway@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/default-gateway/-/default-gateway-4.2.0.tgz#167104c7500c2115f6dd69b0a536bb8ed720552b"
@@ -6474,6 +6479,11 @@ shebang-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
 
+shvl@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/shvl/-/shvl-2.0.3.tgz#eb4bd37644f5684bba1fc52c3010c96fb5e6afd1"
+  integrity sha512-V7C6S9Hlol6SzOJPnQ7qzOVEWUQImt3BNmmzh40wObhla3XOYMe4gGiYzLrJd5TFa+cI2f9LKIRJTTKZSTbWgw==
+
 side-channel@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
@@ -7316,6 +7326,14 @@ vue@^2.6.14:
   version "2.6.14"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.14.tgz#e51aa5250250d569a3fbad3a8a5a687d6036e235"
   integrity sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ==
+
+vuex-persistedstate@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/vuex-persistedstate/-/vuex-persistedstate-4.1.0.tgz#127165f85f5b4534fb3170a5d3a8be9811bd2a53"
+  integrity sha512-3SkEj4NqwM69ikJdFVw6gObeB0NHyspRYMYkR/EbhR0hbvAKyR5gksVhtAfY1UYuWUOCCA0QNGwv9pOwdj+XUQ==
+  dependencies:
+    deepmerge "^4.2.2"
+    shvl "^2.0.3"
 
 vuex@^3.6.2:
   version "3.6.2"


### PR DESCRIPTION
## 概要
- 選択された検定の情報を保持するために、Vuexとvue-persistedstateを導入
- 検定ごとの確認項目を管理するための、CheckItemモデルを追加
- ExamとCheckItemの初期データと用意するためのseeds.rbを作成
- 検定詳細ページの実装(受検機能は未実装)
![image](https://user-images.githubusercontent.com/84756197/144852206-123cbea4-2827-45db-8809-923cb65e622a.png)
![image](https://user-images.githubusercontent.com/84756197/144852061-36f6049e-b1ad-4d78-a12a-996c642a8915.png)


## 確認方法
- 検定一覧ページで選択した検定の情報がlogalstorage上に保存されていること
```
jojoPoseExam: { 
  exams: { 
    selectedExam: {
      created_at: "2021-12-06T07:05:55.107Z"
      description: "第5部「黄金の風」の第5話「ブチャラティが来る② 」..."
      id: 1
      path: "giorno"
      title: "ジョルノ立ち"
      updated_at: "2021-12-06T07:05:55.107Z"
    }
  }
}
```
- 検定詳細ページが表示できること

close #18 