### PR TITLE
アップロード画像のバリデーションを実装

### DIFF
--- a/app/javascript/packs/hello_vue.js
+++ b/app/javascript/packs/hello_vue.js
@@ -5,7 +5,7 @@ import 'bootstrap/dist/css/bootstrap.css'
 import 'bootstrap-vue/dist/bootstrap-vue.css'
 import router from './router.js'
 import store from '../store/store.js'
-import '../plugins/validation.<i class="fa fa-jsfiddle" aria-hidden="true"></i>'
+import '../plugins/validation.js'
 
 Vue.config.productionTip = false
 Vue.prototype.$axios = axios

--- a/app/javascript/packs/hello_vue.js
+++ b/app/javascript/packs/hello_vue.js
@@ -5,6 +5,7 @@ import 'bootstrap/dist/css/bootstrap.css'
 import 'bootstrap-vue/dist/bootstrap-vue.css'
 import router from './router.js'
 import store from '../store/store.js'
+import '../plugins/validation.<i class="fa fa-jsfiddle" aria-hidden="true"></i>'
 
 Vue.config.productionTip = false
 Vue.prototype.$axios = axios

--- a/app/javascript/pages/exam/index.vue
+++ b/app/javascript/pages/exam/index.vue
@@ -37,6 +37,7 @@
           <input
             id="jojo-pose-image"
             type="file"
+            accept="image/*"
             class="form-control-file"
             @change="handleChange"
           >

--- a/app/javascript/pages/exam/index.vue
+++ b/app/javascript/pages/exam/index.vue
@@ -20,26 +20,41 @@
       </div>
     </div>
 
-    <div class="form-group mt-4">
-      <label
-        for="jojo-pose-image"
-        class="d-block"
-      >ジョジョ立ち画像を添付</label>
-      <input
-        id="jojo-pose-image"
-        type="file"
-        class="form-control-file"
+    <ValidationObserver v-slot="{ handleSubmit }">
+      <!-- eslint-disable vue/no-unused-vars -->
+      <ValidationProvider
+        v-slot="{ errors, validate }"
+        ref="provider"
+        name="ジョジョ立ち画像"
+        rules="required|image"
       >
+        <div class="form-group mt-4">
+          <label
+            for="jojo-pose-image"
+            class="d-block"
+          >ジョジョ立ち画像を添付</label>
+
+          <input
+            id="jojo-pose-image"
+            type="file"
+            class="form-control-file"
+            @change="handleChange"
+          >
+          <span class="text-danger">{{ errors[0] }}</span>
+        </div>
+      </ValidationProvider>
+      
       <div class="text-center my-4">
         <button
           type="submit"
           class="btn btn-secondary"
-          @click="takeExam()"
+          @click="handleSubmit(takeExam)"
         >
           受検するッ！
         </button>
       </div>
-    </div>
+    </ValidationObserver>
+
   </div>
 </template>
 
@@ -74,6 +89,11 @@ export default {
     },
     takeExam(){
       console.log("受検ッ")
+    },
+    async handleChange(e){
+      const { valid } = await this.$refs.provider.validate(e) // バリデーションチェック
+      if (valid) console.log("valid")
+      // if (valid) this.uploadAvatar = e.target.files[0] // イベントオブジェクトからファイルを取得して、dataに格納
     }
   }
 

--- a/app/javascript/plugins/validation.js
+++ b/app/javascript/plugins/validation.js
@@ -1,9 +1,19 @@
 import Vue from 'vue'
 import { ValidationObserver, ValidationProvider, extend } from 'vee-validate'
+import { required, image } from 'vee-validate/dist/rules'
+
 
 Vue.component('ValidationObserver', ValidationObserver)
 Vue.component('ValidationProvider', ValidationProvider)
 
+extend('required', {
+  ...required,
+  message: '{_field_}は必須項目です'
+})
 
+extend('image', {
+  ...image,
+  message: '{_field_}は画像形式で入力してください'
+})
 
 export default ValidationProvider

--- a/app/javascript/plugins/validation.js
+++ b/app/javascript/plugins/validation.js
@@ -1,0 +1,9 @@
+import Vue from 'vue'
+import { ValidationObserver, ValidationProvider, extend } from 'vee-validate'
+
+Vue.component('ValidationObserver', ValidationObserver)
+Vue.component('ValidationProvider', ValidationProvider)
+
+
+
+export default ValidationProvider

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "axios": "^0.24.0",
     "bootstrap-vue": "^2.21.2",
     "turbolinks": "^5.2.0",
+    "vee-validate": "^3.4.14",
     "vue": "^2.6.14",
     "vue-loader": "^15.9.8",
     "vue-router": "^3.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7252,6 +7252,11 @@ vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
+vee-validate@^3.4.14:
+  version "3.4.14"
+  resolved "https://registry.yarnpkg.com/vee-validate/-/vee-validate-3.4.14.tgz#51f91c01d6660c43c6252c417c89fb07cdf8b8dd"
+  integrity sha512-Hqqic8G9WcRSIzCxiCPqMZv4qB8JE1lIQqIOLDm2K5BXUiL8d4a2+kqkanv8gQSGDzYpnCQZ7BO/T99Aj05T1Q==
+
 vendors@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/vendors/-/vendors-1.0.4.tgz#e2b800a53e7a29b93506c3cf41100d16c4c4ad8e"


### PR DESCRIPTION
## 概要
- vee-validateの導入
- アップロード画像のバリでージョンを実装
- アップロード画像のinput要素にaccept属性を指定
![image](https://user-images.githubusercontent.com/84756197/144978864-5aeeb8b1-8dca-4080-90a0-ab1dece0c025.png)

## 確認方法
- 画像を未選択の状態で「受験する」ボタンを押下した際に、バリデーションエラーが発生すること
- 画像の選択時に、画像以外のファイルを選択できないこと

close #20 