### PR TITLE
各モデルのvalidateを追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,7 @@ AllCops:
   - 'bin/**/*'
   - 'spec/**/*'
   - 'node_modules/**/*'
+  - 'lib/tasks/auto_annotate_models.rake'
   DisplayCopNames: true
 
 Layout/MultilineBlockLayout:

--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ group :development do
   gem 'better_errors'
   gem 'binding_of_caller'
   gem 'rails-erd'
+  gem 'annotate'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,9 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
+    annotate (3.1.1)
+      activerecord (>= 3.2, < 7.0)
+      rake (>= 10.4, < 14.0)
     ast (2.4.2)
     better_errors (2.9.1)
       coderay (>= 1.0.0)
@@ -270,6 +273,7 @@ PLATFORMS
   x86_64-darwin-20
 
 DEPENDENCIES
+  annotate
   better_errors
   binding_of_caller
   bootsnap (>= 1.4.4)

--- a/app/models/check_item.rb
+++ b/app/models/check_item.rb
@@ -19,10 +19,15 @@ class CheckItem < ApplicationRecord
   has_many :check_item_results, dependent: :destroy
   has_many :exam_results, through: :check_item_results
 
-  validates :exam, presence: true
-  validates :content, presence: true
-  validates :allocation, presence: true
-  validates :check_pattern, presence: true
+  with_options presence: true do
+    validates :exam
+    validates :content
+    validates :allocation
+    validates :check_pattern
+  end
+
+  validates :content, length: { maximum: 50 }
+  validates :allocation, inclusion: { in: 0..100 }
 
   enum check_pattern: {
     nose_between_rl_hip: 1,

--- a/app/models/check_item.rb
+++ b/app/models/check_item.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: check_items
+#
+#  id            :bigint           not null, primary key
+#  allocation    :integer          not null
+#  check_pattern :integer          not null
+#  content       :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  exam_id       :bigint           not null
+#
+# Indexes
+#
+#  index_check_items_on_exam_id  (exam_id)
+#
 class CheckItem < ApplicationRecord
   belongs_to :exam
   has_many :check_item_results, dependent: :destroy

--- a/app/models/check_item_result.rb
+++ b/app/models/check_item_result.rb
@@ -6,8 +6,8 @@
 #  result         :boolean          default(FALSE), not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
-#  check_item_id  :bigint
-#  exam_result_id :bigint
+#  check_item_id  :bigint           not null
+#  exam_result_id :bigint           not null
 #
 # Indexes
 #
@@ -18,6 +18,13 @@ class CheckItemResult < ApplicationRecord
   require 'matrix'
   belongs_to :exam_result
   belongs_to :check_item
+
+  with_options presence: true do
+    validates :exam_result
+    validates :check_item
+  end
+
+  validates :result, inclusion: { in: [true, false] }
 
   def correct_false_judge(keypoints)
     self.result =

--- a/app/models/check_item_result.rb
+++ b/app/models/check_item_result.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: check_item_results
+#
+#  id             :bigint           not null, primary key
+#  result         :boolean          default(FALSE), not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  check_item_id  :bigint
+#  exam_result_id :bigint
+#
+# Indexes
+#
+#  index_check_item_results_on_check_item_id   (check_item_id)
+#  index_check_item_results_on_exam_result_id  (exam_result_id)
+#
 class CheckItemResult < ApplicationRecord
   require 'matrix'
   belongs_to :exam_result

--- a/app/models/exam.rb
+++ b/app/models/exam.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: exams
+#
+#  id          :bigint           not null, primary key
+#  description :string
+#  path        :string           not null
+#  title       :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 class Exam < ApplicationRecord
   has_many :check_items, dependent: :destroy
   has_many :exam_results, dependent: :destroy

--- a/app/models/exam.rb
+++ b/app/models/exam.rb
@@ -13,6 +13,11 @@ class Exam < ApplicationRecord
   has_many :check_items, dependent: :destroy
   has_many :exam_results, dependent: :destroy
 
-  validates :title, presence: true
-  validates :path, presence: true
+  with_options presence: true do
+    validates :title
+    validates :path
+  end
+
+  validates :title, length: { maximum: 30 }
+  validates :description, length: { maximum: 1000 }
 end

--- a/app/models/exam_result.rb
+++ b/app/models/exam_result.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: exam_results
+#
+#  id              :bigint           not null, primary key
+#  hide_face       :boolean          default(FALSE), not null
+#  privacy_setting :boolean          default(TRUE), not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  exam_id         :bigint
+#
+# Indexes
+#
+#  index_exam_results_on_exam_id  (exam_id)
+#
 class ExamResult < ApplicationRecord
   belongs_to :exam
   has_many :check_item_results, dependent: :destroy

--- a/app/models/exam_result.rb
+++ b/app/models/exam_result.rb
@@ -7,7 +7,7 @@
 #  privacy_setting :boolean          default(TRUE), not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
-#  exam_id         :bigint
+#  exam_id         :bigint           not null
 #
 # Indexes
 #
@@ -18,6 +18,15 @@ class ExamResult < ApplicationRecord
   has_many :check_item_results, dependent: :destroy
   has_many :check_items, through: :check_item_results
   has_many :exam_result_keypoints, dependent: :destroy
+
+  with_options presence: true do
+    validates :exam
+    validates :check_item_results
+    validates :exam_result_keypoints
+  end
+
+  validates :hide_face, inclusion: { in: [true, false] }
+  validates :privacy_setting, inclusion: { in: [true, false] }
 
   attr_writer :exam_id, :privacy_setting, :hide_face, :exam_result_keypoints
 

--- a/app/models/exam_result_keypoint.rb
+++ b/app/models/exam_result_keypoint.rb
@@ -3,13 +3,13 @@
 # Table name: exam_result_keypoints
 #
 #  id             :bigint           not null, primary key
-#  score          :integer
-#  x_coordinate   :integer
-#  y_coordinate   :integer
+#  score          :integer          not null
+#  x_coordinate   :integer          not null
+#  y_coordinate   :integer          not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
-#  exam_result_id :bigint
-#  keypoint_id    :bigint
+#  exam_result_id :bigint           not null
+#  keypoint_id    :bigint           not null
 #
 # Indexes
 #
@@ -19,4 +19,16 @@
 class ExamResultKeypoint < ApplicationRecord
   belongs_to :exam_result
   belongs_to :keypoint
+
+  with_options presence: true do
+    validates :score
+    validates :x_coordinate
+    validates :y_coordinate
+    validates :exam_result
+    validates :keypoint
+  end
+
+  validates :x_coordinate, inclusion: { in: 0..9999 }
+  validates :y_coordinate, inclusion: { in: 0..9999 }
+  validates :score, inclusion: { in: 0..100 }
 end

--- a/app/models/exam_result_keypoint.rb
+++ b/app/models/exam_result_keypoint.rb
@@ -1,3 +1,21 @@
+# == Schema Information
+#
+# Table name: exam_result_keypoints
+#
+#  id             :bigint           not null, primary key
+#  score          :integer
+#  x_coordinate   :integer
+#  y_coordinate   :integer
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  exam_result_id :bigint
+#  keypoint_id    :bigint
+#
+# Indexes
+#
+#  index_exam_result_keypoints_on_exam_result_id  (exam_result_id)
+#  index_exam_result_keypoints_on_keypoint_id     (keypoint_id)
+#
 class ExamResultKeypoint < ApplicationRecord
   belongs_to :exam_result
   belongs_to :keypoint

--- a/app/models/keypoint.rb
+++ b/app/models/keypoint.rb
@@ -1,3 +1,12 @@
+# == Schema Information
+#
+# Table name: keypoints
+#
+#  id         :bigint           not null, primary key
+#  name       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 class Keypoint < ApplicationRecord
   has_many :exam_result_keypoints, dependent: :destroy
 end

--- a/app/models/keypoint.rb
+++ b/app/models/keypoint.rb
@@ -9,4 +9,6 @@
 #
 class Keypoint < ApplicationRecord
   has_many :exam_result_keypoints, dependent: :destroy
+  validates :name, presence: true
+  validates :name, length: { maximum: 30 }
 end

--- a/db/migrate/20211208132722_create_exam_results.rb
+++ b/db/migrate/20211208132722_create_exam_results.rb
@@ -1,7 +1,7 @@
 class CreateExamResults < ActiveRecord::Migration[6.1]
   def change
     create_table :exam_results do |t|
-      t.belongs_to :exam
+      t.belongs_to :exam, null: false
       t.boolean :privacy_setting, null: false, default: true
       t.boolean :hide_face, null: false, default: false
 

--- a/db/migrate/20211208134610_create_check_item_results.rb
+++ b/db/migrate/20211208134610_create_check_item_results.rb
@@ -1,8 +1,8 @@
 class CreateCheckItemResults < ActiveRecord::Migration[6.1]
   def change
     create_table :check_item_results do |t|
-      t.belongs_to :exam_result
-      t.belongs_to :check_item
+      t.belongs_to :exam_result, null: false
+      t.belongs_to :check_item, null: false
       t.boolean :result, null: false, default: false
 
       t.timestamps

--- a/db/migrate/20211208150355_create_exam_result_keypoints.rb
+++ b/db/migrate/20211208150355_create_exam_result_keypoints.rb
@@ -1,11 +1,11 @@
 class CreateExamResultKeypoints < ActiveRecord::Migration[6.1]
   def change
     create_table :exam_result_keypoints do |t|
-      t.belongs_to :exam_result
-      t.belongs_to :keypoint
-      t.integer :x_coordinate
-      t.integer :y_coordinate
-      t.integer :score
+      t.belongs_to :exam_result, null: false
+      t.belongs_to :keypoint, null: false
+      t.integer :x_coordinate, null: false
+      t.integer :y_coordinate, null: false
+      t.integer :score, null: false
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,8 +16,8 @@ ActiveRecord::Schema.define(version: 2021_12_08_150355) do
   enable_extension "plpgsql"
 
   create_table "check_item_results", force: :cascade do |t|
-    t.bigint "exam_result_id"
-    t.bigint "check_item_id"
+    t.bigint "exam_result_id", null: false
+    t.bigint "check_item_id", null: false
     t.boolean "result", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -36,11 +36,11 @@ ActiveRecord::Schema.define(version: 2021_12_08_150355) do
   end
 
   create_table "exam_result_keypoints", force: :cascade do |t|
-    t.bigint "exam_result_id"
-    t.bigint "keypoint_id"
-    t.integer "x_coordinate"
-    t.integer "y_coordinate"
-    t.integer "score"
+    t.bigint "exam_result_id", null: false
+    t.bigint "keypoint_id", null: false
+    t.integer "x_coordinate", null: false
+    t.integer "y_coordinate", null: false
+    t.integer "score", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["exam_result_id"], name: "index_exam_result_keypoints_on_exam_result_id"
@@ -48,7 +48,7 @@ ActiveRecord::Schema.define(version: 2021_12_08_150355) do
   end
 
   create_table "exam_results", force: :cascade do |t|
-    t.bigint "exam_id"
+    t.bigint "exam_id", null: false
     t.boolean "privacy_setting", default: true, null: false
     t.boolean "hide_face", default: false, null: false
     t.datetime "created_at", precision: 6, null: false

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,59 @@
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.development?
+  require 'annotate'
+  task :set_annotation_options do
+    # You can override any of these by setting an environment variable of the
+    # same name.
+    Annotate.set_defaults(
+      'active_admin'                => 'false',
+      'additional_file_patterns'    => [],
+      'routes'                      => 'false',
+      'models'                      => 'true',
+      'position_in_routes'          => 'before',
+      'position_in_class'           => 'before',
+      'position_in_test'            => 'before',
+      'position_in_fixture'         => 'before',
+      'position_in_factory'         => 'before',
+      'position_in_serializer'      => 'before',
+      'show_foreign_keys'           => 'true',
+      'show_complete_foreign_keys'  => 'false',
+      'show_indexes'                => 'true',
+      'simple_indexes'              => 'false',
+      'model_dir'                   => 'app/models',
+      'root_dir'                    => '',
+      'include_version'             => 'false',
+      'require'                     => '',
+      'exclude_tests'               => 'false',
+      'exclude_fixtures'            => 'false',
+      'exclude_factories'           => 'false',
+      'exclude_serializers'         => 'false',
+      'exclude_scaffolds'           => 'true',
+      'exclude_controllers'         => 'true',
+      'exclude_helpers'             => 'true',
+      'exclude_sti_subclasses'      => 'false',
+      'ignore_model_sub_dir'        => 'false',
+      'ignore_columns'              => nil,
+      'ignore_routes'               => nil,
+      'ignore_unknown_models'       => 'false',
+      'hide_limit_column_types'     => 'integer,bigint,boolean',
+      'hide_default_column_types'   => 'json,jsonb,hstore',
+      'skip_on_db_migrate'          => 'false',
+      'format_bare'                 => 'true',
+      'format_rdoc'                 => 'false',
+      'format_yard'                 => 'false',
+      'format_markdown'             => 'false',
+      'sort'                        => 'false',
+      'force'                       => 'false',
+      'frozen'                      => 'false',
+      'classified_sort'             => 'true',
+      'trace'                       => 'false',
+      'wrapper_open'                => nil,
+      'wrapper_close'               => nil,
+      'with_comment'                => 'true'
+    )
+  end
+
+  Annotate.load_tasks
+end

--- a/spec/factories/check_item_results.rb
+++ b/spec/factories/check_item_results.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: check_item_results
+#
+#  id             :bigint           not null, primary key
+#  result         :boolean          default(FALSE), not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  check_item_id  :bigint
+#  exam_result_id :bigint
+#
+# Indexes
+#
+#  index_check_item_results_on_check_item_id   (check_item_id)
+#  index_check_item_results_on_exam_result_id  (exam_result_id)
+#
 FactoryBot.define do
   factory :check_item_result do
     result { false }

--- a/spec/factories/check_item_results.rb
+++ b/spec/factories/check_item_results.rb
@@ -6,8 +6,8 @@
 #  result         :boolean          default(FALSE), not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
-#  check_item_id  :bigint
-#  exam_result_id :bigint
+#  check_item_id  :bigint           not null
+#  exam_result_id :bigint           not null
 #
 # Indexes
 #

--- a/spec/factories/check_items.rb
+++ b/spec/factories/check_items.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: check_items
+#
+#  id            :bigint           not null, primary key
+#  allocation    :integer          not null
+#  check_pattern :integer          not null
+#  content       :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  exam_id       :bigint           not null
+#
+# Indexes
+#
+#  index_check_items_on_exam_id  (exam_id)
+#
 FactoryBot.define do
   factory :check_item do
     exam { nil }

--- a/spec/factories/exam_result_keypoints.rb
+++ b/spec/factories/exam_result_keypoints.rb
@@ -3,13 +3,13 @@
 # Table name: exam_result_keypoints
 #
 #  id             :bigint           not null, primary key
-#  score          :integer
-#  x_coordinate   :integer
-#  y_coordinate   :integer
+#  score          :integer          not null
+#  x_coordinate   :integer          not null
+#  y_coordinate   :integer          not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
-#  exam_result_id :bigint
-#  keypoint_id    :bigint
+#  exam_result_id :bigint           not null
+#  keypoint_id    :bigint           not null
 #
 # Indexes
 #

--- a/spec/factories/exam_result_keypoints.rb
+++ b/spec/factories/exam_result_keypoints.rb
@@ -1,3 +1,21 @@
+# == Schema Information
+#
+# Table name: exam_result_keypoints
+#
+#  id             :bigint           not null, primary key
+#  score          :integer
+#  x_coordinate   :integer
+#  y_coordinate   :integer
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  exam_result_id :bigint
+#  keypoint_id    :bigint
+#
+# Indexes
+#
+#  index_exam_result_keypoints_on_exam_result_id  (exam_result_id)
+#  index_exam_result_keypoints_on_keypoint_id     (keypoint_id)
+#
 FactoryBot.define do
   factory :exam_result_keypoint do
     x_coordinate { 1 }

--- a/spec/factories/exam_results.rb
+++ b/spec/factories/exam_results.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: exam_results
+#
+#  id              :bigint           not null, primary key
+#  hide_face       :boolean          default(FALSE), not null
+#  privacy_setting :boolean          default(TRUE), not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  exam_id         :bigint
+#
+# Indexes
+#
+#  index_exam_results_on_exam_id  (exam_id)
+#
 FactoryBot.define do
   factory :exam_result do
     privacy_setting { false }

--- a/spec/factories/exam_results.rb
+++ b/spec/factories/exam_results.rb
@@ -7,7 +7,7 @@
 #  privacy_setting :boolean          default(TRUE), not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
-#  exam_id         :bigint
+#  exam_id         :bigint           not null
 #
 # Indexes
 #

--- a/spec/factories/exams.rb
+++ b/spec/factories/exams.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: exams
+#
+#  id          :bigint           not null, primary key
+#  description :string
+#  path        :string           not null
+#  title       :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 FactoryBot.define do
   factory :exam do
     title { "MyString" }

--- a/spec/factories/keypoints.rb
+++ b/spec/factories/keypoints.rb
@@ -1,3 +1,12 @@
+# == Schema Information
+#
+# Table name: keypoints
+#
+#  id         :bigint           not null, primary key
+#  name       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 FactoryBot.define do
   factory :keypoint do
     name { "MyString" }

--- a/spec/models/check_item_result_spec.rb
+++ b/spec/models/check_item_result_spec.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: check_item_results
+#
+#  id             :bigint           not null, primary key
+#  result         :boolean          default(FALSE), not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  check_item_id  :bigint
+#  exam_result_id :bigint
+#
+# Indexes
+#
+#  index_check_item_results_on_check_item_id   (check_item_id)
+#  index_check_item_results_on_exam_result_id  (exam_result_id)
+#
 require 'rails_helper'
 
 RSpec.describe CheckItemResult, type: :model do

--- a/spec/models/check_item_result_spec.rb
+++ b/spec/models/check_item_result_spec.rb
@@ -6,8 +6,8 @@
 #  result         :boolean          default(FALSE), not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
-#  check_item_id  :bigint
-#  exam_result_id :bigint
+#  check_item_id  :bigint           not null
+#  exam_result_id :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/check_item_spec.rb
+++ b/spec/models/check_item_spec.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: check_items
+#
+#  id            :bigint           not null, primary key
+#  allocation    :integer          not null
+#  check_pattern :integer          not null
+#  content       :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  exam_id       :bigint           not null
+#
+# Indexes
+#
+#  index_check_items_on_exam_id  (exam_id)
+#
 require 'rails_helper'
 
 RSpec.describe CheckItem, type: :model do

--- a/spec/models/exam_result_keypoint_spec.rb
+++ b/spec/models/exam_result_keypoint_spec.rb
@@ -3,13 +3,13 @@
 # Table name: exam_result_keypoints
 #
 #  id             :bigint           not null, primary key
-#  score          :integer
-#  x_coordinate   :integer
-#  y_coordinate   :integer
+#  score          :integer          not null
+#  x_coordinate   :integer          not null
+#  y_coordinate   :integer          not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
-#  exam_result_id :bigint
-#  keypoint_id    :bigint
+#  exam_result_id :bigint           not null
+#  keypoint_id    :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/exam_result_keypoint_spec.rb
+++ b/spec/models/exam_result_keypoint_spec.rb
@@ -1,3 +1,21 @@
+# == Schema Information
+#
+# Table name: exam_result_keypoints
+#
+#  id             :bigint           not null, primary key
+#  score          :integer
+#  x_coordinate   :integer
+#  y_coordinate   :integer
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  exam_result_id :bigint
+#  keypoint_id    :bigint
+#
+# Indexes
+#
+#  index_exam_result_keypoints_on_exam_result_id  (exam_result_id)
+#  index_exam_result_keypoints_on_keypoint_id     (keypoint_id)
+#
 require 'rails_helper'
 
 RSpec.describe ExamResultKeypoint, type: :model do

--- a/spec/models/exam_result_spec.rb
+++ b/spec/models/exam_result_spec.rb
@@ -7,7 +7,7 @@
 #  privacy_setting :boolean          default(TRUE), not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
-#  exam_id         :bigint
+#  exam_id         :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/exam_result_spec.rb
+++ b/spec/models/exam_result_spec.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: exam_results
+#
+#  id              :bigint           not null, primary key
+#  hide_face       :boolean          default(FALSE), not null
+#  privacy_setting :boolean          default(TRUE), not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  exam_id         :bigint
+#
+# Indexes
+#
+#  index_exam_results_on_exam_id  (exam_id)
+#
 require 'rails_helper'
 
 RSpec.describe ExamResult, type: :model do

--- a/spec/models/exam_spec.rb
+++ b/spec/models/exam_spec.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: exams
+#
+#  id          :bigint           not null, primary key
+#  description :string
+#  path        :string           not null
+#  title       :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 require 'rails_helper'
 
 RSpec.describe Exam, type: :model do

--- a/spec/models/keypoint_spec.rb
+++ b/spec/models/keypoint_spec.rb
@@ -1,3 +1,12 @@
+# == Schema Information
+#
+# Table name: keypoints
+#
+#  id         :bigint           not null, primary key
+#  name       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 require 'rails_helper'
 
 RSpec.describe Keypoint, type: :model do


### PR DESCRIPTION
## 概要
- モデルファイルにスキーマ情報を出力するために[annotate](https://github.com/ctran/annotate_models)を導入_#25
 - 各モデルのvalidateを追加
 - 各モデルのvalidateにあわせてマイグレーションファイルを変更_#25

## 確認方法
- マイグレーションファイルを修正したため、以下を実行する
```
bin/rails db:migrate:reset
be rails db:seed
```
- 各モデルにvalidateが追加されていることを確認
