### PR TITLE
ジョジョ立ち画像のアップロード機能を実装

### DIFF
--- a/app/controllers/api/exam_results_controller.rb
+++ b/app/controllers/api/exam_results_controller.rb
@@ -8,9 +8,28 @@ class Api::ExamResultsController < ApplicationController
     end
   end
 
+  def upload_image
+    exam_result = ExamResult.find(params[:id])
+    if exam_result.update(upload_image_prams)
+      render json: exam_result, methods: [:upload_image_url]
+    else
+      render json: exam_result.errors, status: :bad_request
+    end
+  end
+
   private
 
   def exam_result_params
-    params.require(:exam_result).permit(:exam_id, :privacy_setting, :hide_face, exam_result_keypoints: %i[x_coordinate y_coordinate score name])
+    params.require(:exam_result).permit(
+      :exam_id,
+      :privacy_setting,
+      :hide_face,
+      :upload_image,
+      exam_result_keypoints: %i[x_coordinate y_coordinate score name]
+    )
+  end
+
+  def upload_image_prams
+    params.require(:exam_result).permit(:upload_image)
   end
 end

--- a/app/models/exam_result.rb
+++ b/app/models/exam_result.rb
@@ -18,6 +18,7 @@ class ExamResult < ApplicationRecord
   has_many :check_item_results, dependent: :destroy
   has_many :check_items, through: :check_item_results
   has_many :exam_result_keypoints, dependent: :destroy
+  has_one_attached :upload_image
 
   with_options presence: true do
     validates :exam
@@ -76,5 +77,9 @@ class ExamResult < ApplicationRecord
       check_item_result.correct_false_judge(@exam_result_keypoints)
       check_item_results << check_item_result
     end
+  end
+
+  def upload_image_url
+    upload_image.attached? ? Rails.application.routes.url_helpers.rails_blob_path(upload_image, only_path: true) : nil
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,14 @@ Rails.application.routes.draw do
   namespace :api, format: 'json' do
     resources :exams, only: %i[index]
     resources :check_items, only: %i[index]
-    resources :exam_results, only: %i[create]
+    resources :exam_results, only: %i[create] do
+      post 'upload_image', on: :member
+    end
   end
 
-  get '*path', to: 'home#index'
+  get '*path', to: 'home#index', constraints: lambda { |req|
+    # active_storageに保存したファイルを参照できるようにするために、
+    # 'rails/active_storage'が含まれているurlはリダイレクト対象外にする
+    req.path.exclude? 'rails/active_storage'
+  }
 end

--- a/db/migrate/20211212065519_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20211212065519_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,36 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum,     null: false
+      t.datetime :created_at,   null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records do |t|
+      t.belongs_to :blob, null: false, index: false
+      t.string :variation_digest, null: false
+
+      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,38 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_08_150355) do
+ActiveRecord::Schema.define(version: 2021_12_12_065519) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "check_item_results", force: :cascade do |t|
     t.bigint "exam_result_id", null: false
@@ -70,4 +98,6 @@ ActiveRecord::Schema.define(version: 2021_12_08_150355) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end


### PR DESCRIPTION
## 概要
- 画像のアップロード用にActiveStorageを導入
- 画像のアップロード処理を実装
  - `exam_results_controller`に`upload_image`アクションを追加
  - 検定詳細ページで「受検するッ」ボタンが押下された際に、`exam_results_controller`の`create`アクションと`upload_image`アクションを実行する
 

## 確認方法
-  検定詳細ページで「受検するッ」ボタンを押下した際に、
`POST /api/exam_results/${exam_result.id}/upload_image`が実行されること

- `POST /api/exam_results/${exam_result.id}/upload_image`のレスポンスにアップロード画像のurlの情報が含まれていること
![image](https://user-images.githubusercontent.com/84756197/145962841-a89f82d6-ec64-4e25-83e2-84f60b973a44.png)


## コメント
- 受検結果(ExamRsult)のcreateに必要となる姿勢推定結果など情報は、json形式で送信したいが、画像データはFormData形式で送信したかったため、別々に送信することにした。
- 画像データをbase64形式に変換すればjson形式で画像データを送信できるが、エンコード・デコードの手間を考慮して、行わなかった。

close #26 