### PR TITLE
検定結果ページの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,8 @@ gem 'jbuilder', '~> 2.7'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false
 
+gem 'alba'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,7 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
+    alba (1.5.0)
     annotate (3.1.1)
       activerecord (>= 3.2, < 7.0)
       rake (>= 10.4, < 14.0)
@@ -273,6 +274,7 @@ PLATFORMS
   x86_64-darwin-20
 
 DEPENDENCIES
+  alba
   annotate
   better_errors
   binding_of_caller

--- a/app/controllers/api/check_items_controller.rb
+++ b/app/controllers/api/check_items_controller.rb
@@ -1,6 +1,7 @@
 class Api::CheckItemsController < ApplicationController
   def index
     @check_items = CheckItem.all
-    render json: @check_items
+    # render json: @check_items # ここ修正
+    render json: CheckItemResource.new(@check_items).serialize
   end
 end

--- a/app/controllers/api/exam_results_controller.rb
+++ b/app/controllers/api/exam_results_controller.rb
@@ -1,23 +1,32 @@
 class Api::ExamResultsController < ApplicationController
+  before_action :set_exam_result, only: %i[show upload_image]
+
   def create
-    exam_result = ExamResult.new(exam_result_params)
-    if exam_result.save
-      render json: exam_result
+    @exam_result = ExamResult.new(exam_result_params)
+    if @exam_result.save
+      render json: ExamResultResource.new(@exam_result).serialize
     else
-      render json: exam_result.errors, status: :bad_request
+      render json: @exam_result.errors, status: :bad_request
     end
   end
 
+  def show
+    render json: ExamResultResource.new(@exam_result).serialize
+  end
+
   def upload_image
-    exam_result = ExamResult.find(params[:id])
-    if exam_result.update(upload_image_prams)
-      render json: exam_result, methods: [:upload_image_url]
+    if @exam_result.update(upload_image_prams)
+      render json: ExamResultResource.new(@exam_result).serialize
     else
-      render json: exam_result.errors, status: :bad_request
+      render json: @exam_result.errors, status: :bad_request
     end
   end
 
   private
+
+  def set_exam_result
+    @exam_result = ExamResult.find(params[:id])
+  end
 
   def exam_result_params
     params.require(:exam_result).permit(

--- a/app/controllers/api/exams_controller.rb
+++ b/app/controllers/api/exams_controller.rb
@@ -1,6 +1,6 @@
 class Api::ExamsController < ApplicationController
   def index
     @exams = Exam.all
-    render json: @exams
+    render json: ExamResource.new(@exams).serialize
   end
 end

--- a/app/javascript/packs/router.js
+++ b/app/javascript/packs/router.js
@@ -3,6 +3,7 @@ import VueRouter from 'vue-router'
 import TopIndex from '../pages/top/index.vue'
 import ExamListIndex from '../pages/exam_list/index.vue'
 import ExamIndex from '../pages/exam/index.vue'
+import ExamResultIndex from '../pages/exam_result/index.vue'
 
 Vue.use(VueRouter)
 
@@ -23,6 +24,14 @@ export default new VueRouter({
       path: '/exam/:exam_path',
       name: 'ExamIndex',
       component: ExamIndex
+    },
+    {
+      path: '/exam_results/:exam_result_id',
+      name: 'ExamResultIndex',
+      component: ExamResultIndex,
+      props: routes => ({
+        exam_result_id: Number(routes.params.exam_result_id)
+      })
     }
   ]
 })

--- a/app/javascript/packs/router.js
+++ b/app/javascript/packs/router.js
@@ -30,7 +30,7 @@ export default new VueRouter({
       name: 'ExamResultIndex',
       component: ExamResultIndex,
       props: routes => ({
-        exam_result_id: Number(routes.params.exam_result_id)
+        examResultId: Number(routes.params.exam_result_id)
       })
     }
   ]

--- a/app/javascript/pages/exam/index.vue
+++ b/app/javascript/pages/exam/index.vue
@@ -19,13 +19,16 @@
       <p>{{ selectedExam.description }}</p>
     </div>
 
-    <div
-      v-for="(check_item, index) in selectedExamCheckItems"
-      :key="check_item.id"
-    >
-      <div class="border py-1 my-2">
-        <div class="pl-2 py-1">
-          Point: {{ index + 1 }} {{ check_item.content }}
+    <div class="text-center">
+      <span>~ Point一覧 ~</span>
+      <div
+        v-for="(check_item, index) in selectedExamCheckItems"
+        :key="check_item.id"
+      >
+        <div class="rounded border border-secondary py-1 my-1">
+          <div class="pl-2 py-1">
+            Point: {{ index + 1 }} {{ check_item.content }}
+          </div>
         </div>
       </div>
     </div>
@@ -177,8 +180,10 @@ export default {
           }
         })
         .then(res => {
-          this.uploadImageFile(res.data)
+          const exam_result = res.data.exam_result
+          this.uploadImageFile(exam_result)
           this.isLoading = false
+          this.$router.push({ name: 'ExamResultIndex', params: { exam_result_id: exam_result.id } })
         })
       }, 500)
     }

--- a/app/javascript/pages/exam/index.vue
+++ b/app/javascript/pages/exam/index.vue
@@ -6,7 +6,9 @@
     >
       <div>
         <img :src="require(`../../../assets/images/loading.gif`)">
-        <h4 class="mt-3">解析中ッ</h4>
+        <h4 class="mt-3">
+          解析中ッ
+        </h4>
       </div>
     </loading>
 
@@ -79,6 +81,9 @@ import Loading from 'vue-loading-overlay'
 import 'vue-loading-overlay/dist/vue-loading.css';
 
 export default {
+  components: {
+    Loading
+  },
   data: function () {
     return {
       check_items: [],
@@ -87,9 +92,6 @@ export default {
       image_element: null,
       isLoading: false,
     }
-  },
-  components: {
-    Loading
   },
   computed: {
     ...mapGetters('exams', ['selectedExam']),

--- a/app/javascript/pages/exam_result/index.vue
+++ b/app/javascript/pages/exam_result/index.vue
@@ -1,9 +1,10 @@
 <template>
   <div class="container">
-
     <div class="mt-4">
       <h5>{{ exam_result.exam.title }}検定</h5>
-      <h2 class="text-center">{{ exam_result.total_score }}点 {{ pass_fail }}</h2>
+      <h2 class="text-center">
+        {{ exam_result.total_score }}点 {{ pass_fail }}
+      </h2>
       <img
         class="img-fluid border"
         :src="exam_result.upload_image_url"
@@ -18,15 +19,15 @@
       <div class="text-center mb-3">
         <span>~ 各Pointの結果 ~</span>
         <div
+          v-for="(check_item_result, index) in exam_result.check_item_results"
+          :key="index"
           class="text-center rounded border border-secondary py-1 my-1"
-          v-for="(check_item_result, index) in exam_result.check_item_results" :key="index"
         >
           <span>Point{{ index+1 }}: {{ check_item_result.content }}</span>
           <h5>{{ getResult(check_item_result.result) }}</h5>
         </div>
       </div>
     </div>
-
   </div>
 </template>
 
@@ -34,7 +35,10 @@
 
 export default {
   props: {
-    exam_result_id: Number
+    examResultId: {
+      type: Number,
+      default: null
+    }
   },
   data: function () {
     return {
@@ -52,9 +56,6 @@ export default {
     }
   },
   computed:{
-  },
-  created() {
-    this.getExamResult()
   },
   computed: {
     pass_fail(){
@@ -81,9 +82,12 @@ export default {
       }
     }
   },
+  created() {
+    this.getExamResult()
+  },
   methods: {
     getExamResult(){
-      this.$axios.get(`/api/exam_results/${this.exam_result_id}`)
+      this.$axios.get(`/api/exam_results/${this.examResultId}`)
         .then(res => {
           this.exam_result = res.data.exam_result
           console.log(res.data.exam_result)

--- a/app/javascript/pages/exam_result/index.vue
+++ b/app/javascript/pages/exam_result/index.vue
@@ -1,0 +1,107 @@
+<template>
+  <div class="container">
+
+    <div class="mt-4">
+      <h5>{{ exam_result.exam.title }}検定</h5>
+      <h2 class="text-center">{{ exam_result.total_score }}点 {{ pass_fail }}</h2>
+      <img
+        class="img-fluid border"
+        :src="exam_result.upload_image_url"
+      >
+      <div class="text-center my-3">
+        <span>~ 評価コメント ~</span>
+        <div class="text-center rounded  py-2 border border-secondary">
+          <h5>{{ comment }}</h5>
+        </div>
+      </div>
+
+      <div class="text-center mb-3">
+        <span>~ 各Pointの結果 ~</span>
+        <div
+          class="text-center rounded border border-secondary py-1 my-1"
+          v-for="(check_item_result, index) in exam_result.check_item_results" :key="index"
+        >
+          <span>Point{{ index+1 }}: {{ check_item_result.content }}</span>
+          <h5>{{ getResult(check_item_result.result) }}</h5>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</template>
+
+<script>
+
+export default {
+  props: {
+    exam_result_id: Number
+  },
+  data: function () {
+    return {
+      exam_result:{
+        id: null,
+        total_score: null,
+        upload_image_url: null,
+        check_item_results: [],
+        exam: {
+          id: null,
+          title: "",
+          description: ""
+        }
+      }
+    }
+  },
+  computed:{
+  },
+  created() {
+    this.getExamResult()
+  },
+  computed: {
+    pass_fail(){
+      if (this.exam_result.total_score >= 100){
+        return "合格ッ！"
+      }
+      else {
+        return "不合格！！"
+      }
+    },
+    comment(){
+      const score = this.exam_result.total_score
+      if (score <= 40){
+        return "やれやれだぜ"
+      }
+      else if (score <= 60){
+        return "逆に考えるんだ こんなジョジョ立ちでもいいさと..."
+      }
+      else if (score <= 99){
+        return "ブラボー！おお...ブラボー！！"
+      }
+      else if (score <= 100){
+        return "グレートですよこいつはァ"
+      }
+    }
+  },
+  methods: {
+    getExamResult(){
+      this.$axios.get(`/api/exam_results/${this.exam_result_id}`)
+        .then(res => {
+          this.exam_result = res.data.exam_result
+          console.log(res.data.exam_result)
+        })
+        .catch(err => console.log(err.status))
+    },
+    getResult(result){
+      if(result == true){
+        return "Clear!!"
+      }
+      else{
+        return "Miss..."
+      }
+    }
+  }
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/app/models/exam_result.rb
+++ b/app/models/exam_result.rb
@@ -82,4 +82,12 @@ class ExamResult < ApplicationRecord
   def upload_image_url
     upload_image.attached? ? Rails.application.routes.url_helpers.rails_blob_path(upload_image, only_path: true) : nil
   end
+
+  def total_score
+    score = 0
+    check_item_results.each do |check_item_result|
+      score += check_item_result.check_item.allocation if check_item_result.result
+    end
+    return score
+  end
 end

--- a/app/models/exam_result.rb
+++ b/app/models/exam_result.rb
@@ -88,6 +88,6 @@ class ExamResult < ApplicationRecord
     check_item_results.each do |check_item_result|
       score += check_item_result.check_item.allocation if check_item_result.result
     end
-    return score
+    score
   end
 end

--- a/app/resources/check_item_resource.rb
+++ b/app/resources/check_item_resource.rb
@@ -4,5 +4,4 @@ class CheckItemResource
   root_key :check_item
 
   attributes :id, :exam_id, :content
-
 end

--- a/app/resources/check_item_resource.rb
+++ b/app/resources/check_item_resource.rb
@@ -1,0 +1,8 @@
+class CheckItemResource
+  include Alba::Resource
+
+  root_key :check_item
+
+  attributes :id, :exam_id, :content
+
+end

--- a/app/resources/check_item_result_resource.rb
+++ b/app/resources/check_item_result_resource.rb
@@ -1,0 +1,12 @@
+class CheckItemResultResource
+  include Alba::Resource
+
+  root_key :check_item_result
+
+  attributes :result
+
+  attribute :content do |resource|
+    resource.check_item.content
+  end
+
+end

--- a/app/resources/check_item_result_resource.rb
+++ b/app/resources/check_item_result_resource.rb
@@ -8,5 +8,4 @@ class CheckItemResultResource
   attribute :content do |resource|
     resource.check_item.content
   end
-
 end

--- a/app/resources/exam_resource.rb
+++ b/app/resources/exam_resource.rb
@@ -4,5 +4,4 @@ class ExamResource
   root_key :exam
 
   attributes :id, :title, :description, :path
-
 end

--- a/app/resources/exam_resource.rb
+++ b/app/resources/exam_resource.rb
@@ -1,0 +1,8 @@
+class ExamResource
+  include Alba::Resource
+
+  root_key :exam
+
+  attributes :id, :title, :description, :path
+
+end

--- a/app/resources/exam_result_resource.rb
+++ b/app/resources/exam_result_resource.rb
@@ -1,0 +1,19 @@
+class ExamResultResource
+  include Alba::Resource
+
+  root_key :exam_result
+
+  attributes :id, :privacy_setting
+
+  attribute :upload_image_url do |resource|
+    resource.upload_image_url
+  end
+
+  attribute :total_score do |resource|
+    resource.total_score
+  end
+
+  one :exam, resource: ExamResource
+  many :check_item_results, resource: CheckItemResultResource
+
+end

--- a/app/resources/exam_result_resource.rb
+++ b/app/resources/exam_result_resource.rb
@@ -5,15 +5,10 @@ class ExamResultResource
 
   attributes :id, :privacy_setting
 
-  attribute :upload_image_url do |resource|
-    resource.upload_image_url
-  end
+  attribute :upload_image_url, &:upload_image_url
 
-  attribute :total_score do |resource|
-    resource.total_score
-  end
+  attribute :total_score, &:total_score
 
   one :exam, resource: ExamResource
   many :check_item_results, resource: CheckItemResultResource
-
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   namespace :api, format: 'json' do
     resources :exams, only: %i[index]
     resources :check_items, only: %i[index]
-    resources :exam_results, only: %i[create] do
+    resources :exam_results, only: %i[create show] do
       post 'upload_image', on: :member
     end
   end


### PR DESCRIPTION
## 概要
- JSONシリアライザAlbaを導入
- Exam、ExamResult、CheckItemResult、CheckItem用のJSONシリアライザを追加
- 検定結果ページを実装
- 検定結果の取得用にexam_result_controllerにshowアクションを追加

[![Image from Gyazo](https://i.gyazo.com/68a4c1ec6e5b4c8934d18ef2f2e8a9a7.gif)](https://gyazo.com/68a4c1ec6e5b4c8934d18ef2f2e8a9a7)

## 確認方法
- 受検後に、検定結果ページに遷移すること
- 検定結果ページが正しく表示されること

close #28 