### PR TITLE
検定結果に評価コメント紐付ける

### DIFF
--- a/app/javascript/pages/exam_result/index.vue
+++ b/app/javascript/pages/exam_result/index.vue
@@ -11,8 +11,8 @@
       >
       <div class="text-center my-3">
         <span>~ 評価コメント ~</span>
-        <div class="text-center rounded  py-2 border border-secondary">
-          <h5>{{ comment }}</h5>
+        <div class="text-center rounded border border-secondary">
+          <h5 class="my-2">{{ comment }}</h5>
         </div>
       </div>
 
@@ -51,6 +51,9 @@ export default {
           id: null,
           title: "",
           description: ""
+        },
+        exam_result_comment: {
+          content: ""
         }
       }
     }
@@ -67,19 +70,7 @@ export default {
       }
     },
     comment(){
-      const score = this.exam_result.total_score
-      if (score <= 40){
-        return "やれやれだぜ"
-      }
-      else if (score <= 60){
-        return "逆に考えるんだ こんなジョジョ立ちでもいいさと..."
-      }
-      else if (score <= 99){
-        return "ブラボー！おお...ブラボー！！"
-      }
-      else if (score <= 100){
-        return "グレートですよこいつはァ"
-      }
+      return this.exam_result.exam_result_comment.content
     }
   },
   created() {

--- a/app/models/exam_result_comment.rb
+++ b/app/models/exam_result_comment.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: exam_result_comments
+#
+#  id              :bigint           not null, primary key
+#  content         :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  score_border_id :bigint           not null
+#
+# Indexes
+#
+#  index_exam_result_comments_on_score_border_id  (score_border_id)
+#
+class ExamResultComment < ApplicationRecord
+  has_many :exam_result
+  belongs_to :score_border
+
+  with_options presence: true do
+    validates :content
+    validates :score_border
+  end
+
+  validates :content, length: { maximum: 100 }
+end

--- a/app/models/score_border.rb
+++ b/app/models/score_border.rb
@@ -1,0 +1,15 @@
+# == Schema Information
+#
+# Table name: score_borders
+#
+#  id         :bigint           not null, primary key
+#  score      :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class ScoreBorder < ApplicationRecord
+  has_many :exam_result_comments
+
+  validates :score, presence: true
+  validates :score, inclusion: { in: 0..100 }
+end

--- a/app/resources/exam_result_resource.rb
+++ b/app/resources/exam_result_resource.rb
@@ -10,5 +10,8 @@ class ExamResultResource
   attribute :total_score, &:total_score
 
   one :exam, resource: ExamResource
+  one :exam_result_comment do
+    attributes :content
+  end
   many :check_item_results, resource: CheckItemResultResource
 end

--- a/db/migrate/20211208132722_create_exam_results.rb
+++ b/db/migrate/20211208132722_create_exam_results.rb
@@ -2,6 +2,7 @@ class CreateExamResults < ActiveRecord::Migration[6.1]
   def change
     create_table :exam_results do |t|
       t.belongs_to :exam, null: false
+      t.belongs_to :exam_result_comment, null: false
       t.boolean :privacy_setting, null: false, default: true
       t.boolean :hide_face, null: false, default: false
 

--- a/db/migrate/20211220080819_create_exam_result_comments.rb
+++ b/db/migrate/20211220080819_create_exam_result_comments.rb
@@ -1,0 +1,10 @@
+class CreateExamResultComments < ActiveRecord::Migration[6.1]
+  def change
+    create_table :exam_result_comments do |t|
+      t.belongs_to :score_border, null: false
+      t.string :content, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211220090401_create_score_borders.rb
+++ b/db/migrate/20211220090401_create_score_borders.rb
@@ -1,0 +1,9 @@
+class CreateScoreBorders < ActiveRecord::Migration[6.1]
+  def change
+    create_table :score_borders do |t|
+      t.integer :score, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -85,11 +85,13 @@ ActiveRecord::Schema.define(version: 2021_12_20_090401) do
 
   create_table "exam_results", force: :cascade do |t|
     t.bigint "exam_id", null: false
+    t.bigint "exam_result_comment_id", null: false
     t.boolean "privacy_setting", default: true, null: false
     t.boolean "hide_face", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["exam_id"], name: "index_exam_results_on_exam_id"
+    t.index ["exam_result_comment_id"], name: "index_exam_results_on_exam_result_comment_id"
   end
 
   create_table "exams", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_20_055935) do
+ActiveRecord::Schema.define(version: 2021_12_20_090401) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -63,6 +63,14 @@ ActiveRecord::Schema.define(version: 2021_12_20_055935) do
     t.index ["exam_id"], name: "index_check_items_on_exam_id"
   end
 
+  create_table "exam_result_comments", force: :cascade do |t|
+    t.bigint "score_border_id", null: false
+    t.string "content", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["score_border_id"], name: "index_exam_result_comments_on_score_border_id"
+  end
+
   create_table "exam_result_keypoints", force: :cascade do |t|
     t.bigint "exam_result_id", null: false
     t.bigint "keypoint_id", null: false
@@ -93,6 +101,12 @@ ActiveRecord::Schema.define(version: 2021_12_20_055935) do
 
   create_table "keypoints", force: :cascade do |t|
     t.string "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "score_borders", force: :cascade do |t|
+    t.integer "score", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,6 +1,6 @@
 giorno_exam = Exam.new(
-  title: "ジョルノ立ち",
-  description: "第5部「黄金の風」の第5話「ブチャラティが来る② 」にて、主人公のジョルノ・ジョバーナが行ったジョジョ立ち。ジョルノの回想シーン中で「ギャング・スター」にあこがれるようになったのだ！というナレーションと共に描かれた。"
+  title: 'ジョルノ立ち',
+  description: '第5部「黄金の風」の第5話「ブチャラティが来る② 」にて、主人公のジョルノ・ジョバーナが行ったジョジョ立ち。ジョルノの回想シーン中で「ギャング・スター」にあこがれるようになったのだ！というナレーションと共に描かれた。'
 )
 giorno_exam.save!
 
@@ -8,57 +8,128 @@ CheckItem.create!([
   {
     exam: giorno_exam,
     check_pattern: 1,
-    content: "顎を軽く引き、正面を見据える",
+    content: '顎を軽く引き、正面を見据える',
     allocation: 10
   },
   {
     exam: giorno_exam,
     check_pattern: 2,
-    content: "右肘を曲げ、右手で胸元を掴む",
+    content: '右肘を曲げ、右手で胸元を掴む',
     allocation: 20
   },
   {
     exam: giorno_exam,
     check_pattern: 3,
-    content: "左手を軽く握り、左腿に添える",
+    content: '左手を軽く握り、左腿に添える',
     allocation: 20
   },
   {
     exam: giorno_exam,
     check_pattern: 4,
-    content: "足を大きく開く",
+    content: '足を大きく開く',
     allocation: 10
   },
   {
     exam: giorno_exam,
     check_pattern: 5,
-    content: "右膝を真っ直ぐ斜めに伸ばす",
+    content: '右膝を真っ直ぐ斜めに伸ばす',
     allocation: 20
   },
   {
     exam: giorno_exam,
     check_pattern: 6,
-    content: "左膝を軽く曲げ、踵を浮かす",
+    content: '左膝を軽く曲げ、踵を浮かす',
     allocation: 20
   }
 ])
 
 Keypoint.create!([
-  { name: "nose" },
-  { name: "left_eye" },
-  { name: "right_eye" },
-  { name: "left_ear" },
-  { name: "right_ear" },
-  { name: "left_shoulder" },
-  { name: "right_shoulder" },
-  { name: "left_elbow" },
-  { name: "right_elbow" },
-  { name: "left_wrist" },
-  { name: "right_wrist" },
-  { name: "left_hip" },
-  { name: "right_hip" },
-  { name: "left_knee" },
-  { name: "right_knee" },
-  { name: "left_ankle" },
-  { name: "right_ankle" }
+  { name: 'nose' },
+  { name: 'left_eye' },
+  { name: 'right_eye' },
+  { name: 'left_ear' },
+  { name: 'right_ear' },
+  { name: 'left_shoulder' },
+  { name: 'right_shoulder' },
+  { name: 'left_elbow' },
+  { name: 'right_elbow' },
+  { name: 'left_wrist' },
+  { name: 'right_wrist' },
+  { name: 'left_hip' },
+  { name: 'right_hip' },
+  { name: 'left_knee' },
+  { name: 'right_knee' },
+  { name: 'left_ankle' },
+  { name: 'right_ankle' }
+])
+
+score_border_40 = ScoreBorder.new(
+  score: 40
+)
+score_border_40.save!
+
+score_border_60 = ScoreBorder.new(
+  score: 60
+)
+score_border_60.save!
+
+score_border_99 = ScoreBorder.new(
+  score: 99
+)
+score_border_99.save!
+
+score_border_100 = ScoreBorder.new(
+  score: 100
+)
+score_border_100.save!
+
+ExamResultComment.create!([
+  {
+    content: 'やれやれだぜ',
+    score_border: score_border_40
+  },
+  {
+    content: 'あァァァんまりだァァアァ',
+    score_border: score_border_40
+  },
+  {
+    content: '何をするだァー！',
+    score_border: score_border_40
+  },
+  {
+    content: '貧弱！貧弱ゥ！',
+    score_border: score_border_60
+  },
+  {
+    content: 'そう...一味違うのね',
+    score_border: score_border_60
+  },
+  {
+    content: 'ゴゴゴゴゴ',
+    score_border: score_border_60
+  },
+  {
+    content: 'ブラボー！おお…ブラボー！！',
+    score_border: score_border_99
+  },
+  {
+    content: 'ベネ',
+    score_border: score_border_99
+  },
+  {
+    content: 'メメタァ',
+    score_border: score_border_99
+  },
+  {
+    content: 'グレートですよこいつはァ',
+    score_border: score_border_100
+  },
+  {
+    content: 'きさまこのジョジョ立ちやり込んでいるなッ！',
+    score_border: score_border_100
+  },
+  {
+    content: 'ふるえるぞハート！燃えるきるほどヒート！！',
+    score_border: score_border_100
+  }
 ])

--- a/spec/factories/exam_result_comments.rb
+++ b/spec/factories/exam_result_comments.rb
@@ -1,0 +1,20 @@
+# == Schema Information
+#
+# Table name: exam_result_comments
+#
+#  id              :bigint           not null, primary key
+#  content         :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  score_border_id :bigint           not null
+#
+# Indexes
+#
+#  index_exam_result_comments_on_score_border_id  (score_border_id)
+#
+FactoryBot.define do
+  factory :exam_result_comment do
+    content { "MyString" }
+    score_border { 1 }
+  end
+end

--- a/spec/factories/exam_results.rb
+++ b/spec/factories/exam_results.rb
@@ -2,16 +2,18 @@
 #
 # Table name: exam_results
 #
-#  id              :bigint           not null, primary key
-#  hide_face       :boolean          default(FALSE), not null
-#  privacy_setting :boolean          default(TRUE), not null
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  exam_id         :bigint           not null
+#  id                     :bigint           not null, primary key
+#  hide_face              :boolean          default(FALSE), not null
+#  privacy_setting        :boolean          default(TRUE), not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  exam_id                :bigint           not null
+#  exam_result_comment_id :bigint           not null
 #
 # Indexes
 #
-#  index_exam_results_on_exam_id  (exam_id)
+#  index_exam_results_on_exam_id                 (exam_id)
+#  index_exam_results_on_exam_result_comment_id  (exam_result_comment_id)
 #
 FactoryBot.define do
   factory :exam_result do

--- a/spec/factories/score_borders.rb
+++ b/spec/factories/score_borders.rb
@@ -1,0 +1,14 @@
+# == Schema Information
+#
+# Table name: score_borders
+#
+#  id         :bigint           not null, primary key
+#  score      :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+FactoryBot.define do
+  factory :score_border do
+    score { 1 }
+  end
+end

--- a/spec/models/exam_result_comment_spec.rb
+++ b/spec/models/exam_result_comment_spec.rb
@@ -1,0 +1,19 @@
+# == Schema Information
+#
+# Table name: exam_result_comments
+#
+#  id              :bigint           not null, primary key
+#  content         :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  score_border_id :bigint           not null
+#
+# Indexes
+#
+#  index_exam_result_comments_on_score_border_id  (score_border_id)
+#
+require 'rails_helper'
+
+RSpec.describe ExamResultComment, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/exam_result_spec.rb
+++ b/spec/models/exam_result_spec.rb
@@ -2,16 +2,18 @@
 #
 # Table name: exam_results
 #
-#  id              :bigint           not null, primary key
-#  hide_face       :boolean          default(FALSE), not null
-#  privacy_setting :boolean          default(TRUE), not null
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  exam_id         :bigint           not null
+#  id                     :bigint           not null, primary key
+#  hide_face              :boolean          default(FALSE), not null
+#  privacy_setting        :boolean          default(TRUE), not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  exam_id                :bigint           not null
+#  exam_result_comment_id :bigint           not null
 #
 # Indexes
 #
-#  index_exam_results_on_exam_id  (exam_id)
+#  index_exam_results_on_exam_id                 (exam_id)
+#  index_exam_results_on_exam_result_comment_id  (exam_result_comment_id)
 #
 require 'rails_helper'
 

--- a/spec/models/score_border_spec.rb
+++ b/spec/models/score_border_spec.rb
@@ -1,0 +1,14 @@
+# == Schema Information
+#
+# Table name: score_borders
+#
+#  id         :bigint           not null, primary key
+#  score      :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+require 'rails_helper'
+
+RSpec.describe ScoreBorder, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要
- 評価コメント関連のテーブルを作成
- 検定結果の合計点に対応したコメントを紐付ける処理を追加
- 検定結果ページで、検定結果に紐付いたコメントを表示

## 確認方法
- 検定結果ページで評価コメントが表示されること