### PR TITLE
本番環境の検定結果ページでのアップロード画像表示

### DIFF
--- a/app/javascript/pages/exam/index.vue
+++ b/app/javascript/pages/exam/index.vue
@@ -164,6 +164,10 @@ export default {
         const formData = new FormData()
         formData.append('exam_result[upload_image]', this.image_file)
         this.$axios.post(`/api/exam_results/${exam_result.id}/upload_image`, formData)
+        .then(() => {
+          this.isLoading = false
+          this.$router.push({ name: 'ExamResultIndex', params: { exam_result_id: exam_result.id } })
+        })
       }
     },
 
@@ -182,8 +186,6 @@ export default {
         .then(res => {
           const exam_result = res.data.exam_result
           this.uploadImageFile(exam_result)
-          this.isLoading = false
-          this.$router.push({ name: 'ExamResultIndex', params: { exam_result_id: exam_result.id } })
         })
       }, 500)
     }


### PR DESCRIPTION
## 概要
- 本番環境(heroku)の検定の受験後に、検定結果ページでアップロード画像が表示されないバグを修正。
- フロントエンド側で画像アップロード用のPOSTリクエストのレスポンスを待たずに、 ページ遷移していたことが原因だった
- 詳細については[Notionページ](https://stupendous-motorcycle-eea.notion.site/ActiveStorage-S3-d969714976a0417890fb19fb4931c2b7)を参照

## 確認方法
- 検定受験後に、検定結果ページでアップロード画像が表示されること