### PR TITLE
Add aptfile #66

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,0 +1,3 @@
+libglib2.0-0
+libglib2.0-dev
+libpoppler-glib8

--- a/Aptfile
+++ b/Aptfile
@@ -1,3 +1,0 @@
-libglib2.0-0
-libglib2.0-dev
-libpoppler-glib8


### PR DESCRIPTION
## 概要
- heroku環境でvips buildpackを利用するために必要となるaptパッケージをインストールするために、Aptfileを追加

close #66 

