### PR TITLE
検定結果の主キーをidからuuidに変更

### DIFF
--- a/app/javascript/packs/router.js
+++ b/app/javascript/packs/router.js
@@ -33,7 +33,7 @@ export default new VueRouter({
       name: 'ExamResultIndex',
       component: ExamResultIndex,
       props: routes => ({
-        examResultId: Number(routes.params.exam_result_id)
+        examResultId: routes.params.exam_result_id
       })
     }
   ]

--- a/app/javascript/pages/exam_result/index.vue
+++ b/app/javascript/pages/exam_result/index.vue
@@ -50,7 +50,7 @@
 export default {
   props: {
     examResultId: {
-      type: Number,
+      type: String,
       default: null
     }
   },

--- a/app/models/check_item_result.rb
+++ b/app/models/check_item_result.rb
@@ -7,7 +7,7 @@
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  check_item_id  :bigint           not null
-#  exam_result_id :bigint           not null
+#  exam_result_id :uuid             not null
 #
 # Indexes
 #

--- a/app/models/exam_result.rb
+++ b/app/models/exam_result.rb
@@ -2,7 +2,7 @@
 #
 # Table name: exam_results
 #
-#  id                     :bigint           not null, primary key
+#  id                     :uuid             not null, primary key
 #  hide_face              :boolean          default(FALSE), not null
 #  privacy_setting        :boolean          default(TRUE), not null
 #  created_at             :datetime         not null

--- a/app/models/exam_result_keypoint.rb
+++ b/app/models/exam_result_keypoint.rb
@@ -8,7 +8,7 @@
 #  y_coordinate   :integer          not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
-#  exam_result_id :bigint           not null
+#  exam_result_id :uuid             not null
 #  keypoint_id    :bigint           not null
 #
 # Indexes

--- a/db/migrate/20211208132722_create_exam_results.rb
+++ b/db/migrate/20211208132722_create_exam_results.rb
@@ -1,6 +1,8 @@
 class CreateExamResults < ActiveRecord::Migration[6.1]
   def change
-    create_table :exam_results do |t|
+    enable_extension 'pgcrypto' unless extension_enabled?('pgcrypto')
+
+    create_table :exam_results, id: :uuid do |t|
       t.belongs_to :exam, null: false
       t.belongs_to :exam_result_comment, null: false
       t.boolean :privacy_setting, null: false, default: true

--- a/db/migrate/20211208134610_create_check_item_results.rb
+++ b/db/migrate/20211208134610_create_check_item_results.rb
@@ -1,7 +1,7 @@
 class CreateCheckItemResults < ActiveRecord::Migration[6.1]
   def change
     create_table :check_item_results do |t|
-      t.belongs_to :exam_result, null: false
+      t.belongs_to :exam_result, type: :uuid, null: false
       t.belongs_to :check_item, null: false
       t.boolean :result, null: false, default: false
 

--- a/db/migrate/20211208150355_create_exam_result_keypoints.rb
+++ b/db/migrate/20211208150355_create_exam_result_keypoints.rb
@@ -1,7 +1,7 @@
 class CreateExamResultKeypoints < ActiveRecord::Migration[6.1]
   def change
     create_table :exam_result_keypoints do |t|
-      t.belongs_to :exam_result, null: false
+      t.belongs_to :exam_result, type: :uuid, null: false
       t.belongs_to :keypoint, null: false
       t.integer :x_coordinate, null: false
       t.integer :y_coordinate, null: false

--- a/db/migrate/20211212065519_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20211212065519_create_active_storage_tables.active_storage.rb
@@ -1,7 +1,7 @@
 # This migration comes from active_storage (originally 20170806125915)
 class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
   def change
-    create_table :active_storage_blobs do |t|
+    create_table :active_storage_blobs, id: :uuid do |t|
       t.string   :key,          null: false
       t.string   :filename,     null: false
       t.string   :content_type
@@ -14,10 +14,10 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
       t.index [ :key ], unique: true
     end
 
-    create_table :active_storage_attachments do |t|
+    create_table :active_storage_attachments, id: :uuid do |t|
       t.string     :name,     null: false
-      t.references :record,   null: false, polymorphic: true, index: false
-      t.references :blob,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: :uuid
+      t.references :blob,     null: false, type: :uuid
 
       t.datetime :created_at, null: false
 
@@ -25,8 +25,8 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
 
-    create_table :active_storage_variant_records do |t|
-      t.belongs_to :blob, null: false, index: false
+    create_table :active_storage_variant_records, id: :uuid do |t|
+      t.belongs_to :blob, null: false, index: false, type: :uuid
       t.string :variation_digest, null: false
 
       t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,19 +13,20 @@
 ActiveRecord::Schema.define(version: 2021_12_20_090401) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
-  create_table "active_storage_attachments", force: :cascade do |t|
+  create_table "active_storage_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.bigint "record_id", null: false
-    t.bigint "blob_id", null: false
+    t.uuid "record_id", null: false
+    t.uuid "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
-  create_table "active_storage_blobs", force: :cascade do |t|
+  create_table "active_storage_blobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "key", null: false
     t.string "filename", null: false
     t.string "content_type"
@@ -37,14 +38,14 @@ ActiveRecord::Schema.define(version: 2021_12_20_090401) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "active_storage_variant_records", force: :cascade do |t|
-    t.bigint "blob_id", null: false
+  create_table "active_storage_variant_records", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
   create_table "check_item_results", force: :cascade do |t|
-    t.bigint "exam_result_id", null: false
+    t.uuid "exam_result_id", null: false
     t.bigint "check_item_id", null: false
     t.boolean "result", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
@@ -72,7 +73,7 @@ ActiveRecord::Schema.define(version: 2021_12_20_090401) do
   end
 
   create_table "exam_result_keypoints", force: :cascade do |t|
-    t.bigint "exam_result_id", null: false
+    t.uuid "exam_result_id", null: false
     t.bigint "keypoint_id", null: false
     t.integer "x_coordinate", null: false
     t.integer "y_coordinate", null: false
@@ -83,7 +84,7 @@ ActiveRecord::Schema.define(version: 2021_12_20_090401) do
     t.index ["keypoint_id"], name: "index_exam_result_keypoints_on_keypoint_id"
   end
 
-  create_table "exam_results", force: :cascade do |t|
+  create_table "exam_results", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.bigint "exam_id", null: false
     t.bigint "exam_result_comment_id", null: false
     t.boolean "privacy_setting", default: true, null: false

--- a/spec/factories/check_item_results.rb
+++ b/spec/factories/check_item_results.rb
@@ -7,7 +7,7 @@
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  check_item_id  :bigint           not null
-#  exam_result_id :bigint           not null
+#  exam_result_id :uuid             not null
 #
 # Indexes
 #

--- a/spec/factories/exam_result_keypoints.rb
+++ b/spec/factories/exam_result_keypoints.rb
@@ -8,7 +8,7 @@
 #  y_coordinate   :integer          not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
-#  exam_result_id :bigint           not null
+#  exam_result_id :uuid             not null
 #  keypoint_id    :bigint           not null
 #
 # Indexes

--- a/spec/factories/exam_results.rb
+++ b/spec/factories/exam_results.rb
@@ -2,7 +2,7 @@
 #
 # Table name: exam_results
 #
-#  id                     :bigint           not null, primary key
+#  id                     :uuid             not null, primary key
 #  hide_face              :boolean          default(FALSE), not null
 #  privacy_setting        :boolean          default(TRUE), not null
 #  created_at             :datetime         not null

--- a/spec/models/check_item_result_spec.rb
+++ b/spec/models/check_item_result_spec.rb
@@ -7,7 +7,7 @@
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  check_item_id  :bigint           not null
-#  exam_result_id :bigint           not null
+#  exam_result_id :uuid             not null
 #
 # Indexes
 #

--- a/spec/models/exam_result_keypoint_spec.rb
+++ b/spec/models/exam_result_keypoint_spec.rb
@@ -8,7 +8,7 @@
 #  y_coordinate   :integer          not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
-#  exam_result_id :bigint           not null
+#  exam_result_id :uuid             not null
 #  keypoint_id    :bigint           not null
 #
 # Indexes

--- a/spec/models/exam_result_spec.rb
+++ b/spec/models/exam_result_spec.rb
@@ -2,7 +2,7 @@
 #
 # Table name: exam_results
 #
-#  id                     :bigint           not null, primary key
+#  id                     :uuid             not null, primary key
 #  hide_face              :boolean          default(FALSE), not null
 #  privacy_setting        :boolean          default(TRUE), not null
 #  created_at             :datetime         not null


### PR DESCRIPTION
## 概要
- 検定結果(exam_result)テーブルの主キーをuuidに変更
- 検定結果ページのルートパラメータをidからuuidに変更

## 確認方法
- 検定結果ページにのurlにuuidが使用されていること

close #57