### PR TITLE
ジョジョ立ち画像を適正な向きに回転する

### DIFF
--- a/app/javascript/pages/exam_result/index.vue
+++ b/app/javascript/pages/exam_result/index.vue
@@ -201,11 +201,11 @@ export default {
 }
 
 .pass_underline{
-  background: linear-gradient(transparent 85%, red 100%);
+  background: linear-gradient(transparent 90%, red 50%);
 }
 
 .fail_underline{
-  background: linear-gradient(transparent 85%, blue 100%);
+  background: linear-gradient(transparent 90%, blue 50%);
 }
 
 .card-font{

--- a/app/models/check_item.rb
+++ b/app/models/check_item.rb
@@ -35,6 +35,6 @@ class CheckItem < ApplicationRecord
     l_elbow_angle_125to160: 3,
     rl_leg_angle_100to150: 4,
     r_knee_angle_160to195: 5,
-    l_knee_angle_110to140: 6
+    l_knee_angle_105to140: 6
   }
 end

--- a/app/models/check_item_result.rb
+++ b/app/models/check_item_result.rb
@@ -101,7 +101,7 @@ class CheckItemResult < ApplicationRecord
           max_angle: 195
         )
 
-      when 'l_knee_angle_110to140'
+      when 'l_knee_angle_105to140'
         left_knee = exam_result_keypoints.find { |n| n.keypoint.name == 'left_knee' }
         left_hip = exam_result_keypoints.find { |n| n.keypoint.name == 'left_hip' }
         left_ankle = exam_result_keypoints.find { |n| n.keypoint.name == 'left_ankle' }
@@ -110,7 +110,7 @@ class CheckItemResult < ApplicationRecord
           vertex_keypoint: left_knee,
           side_a_keypoint: left_hip,
           side_b_keypoint: left_ankle,
-          min_angle: 110,
+          min_angle: 105,
           max_angle: 140
         )
       end

--- a/app/models/exam_result.rb
+++ b/app/models/exam_result.rb
@@ -124,6 +124,7 @@ class ExamResult < ApplicationRecord
   end
 
   def preprocess(img)
+    img = img.autorot
     img = img[0..2] if img.bands > 3
     resize_hscale = INPUT_IMG_WIDTH / img.width
     resize_vscale = INPUT_IMG_HEIGHT / img.height


### PR DESCRIPTION
## 概要
- 姿勢推定処理の前に、Exif情報のorientationを参照し、ジョジョ立ち画像を回転させる処理を追加
- 詳細は #64 を参照

close #64