### PR TITLE
アップロード画像をWebP形式に変換

### DIFF
--- a/app/controllers/api/exam_results_controller.rb
+++ b/app/controllers/api/exam_results_controller.rb
@@ -3,13 +3,17 @@ class Api::ExamResultsController < ApplicationController
 
   def create
     @exam_result = ExamResult.new(exam_result_params)
-    @exam_result.upload_image_tmpfile = exam_result_params['upload_image'].tempfile
+
+    upload_image_file = exam_result_params['upload_image']
+    @exam_result.upload_image_vips = Vips::Image.new_from_file(upload_image_file.tempfile.path).autorot
+    @exam_result.upload_image_name = "#{upload_image_file.original_filename}.webp"
 
     if @exam_result.save
       render json: ExamResultResource.new(@exam_result).serialize
     else
       render json: @exam_result.errors, status: :bad_request
     end
+    @exam_result.delete_tmp_image
   end
 
   def show


### PR DESCRIPTION
## 概要
- 容量削減のために、アップロード画像のリサイズ処理とWebP変換処理を追加した
  - リサイズにはruby-vipsの[thumbnail_image関数](https://libvips.github.io/ruby-vips/Vips/Image.html#thumbnail_image-instance_method)を用いた
  - アスペクト比を保持した状態で幅1008pxの画像にリサイズする
  - WebP変換にはruby-vipsの[webpsave関数](https://libvips.github.io/ruby-vips/Vips/Image.html#webpsave-instance_method)を用いた
- リサイズ + WebP変換によって95％以上も容量削減できるようになった
   (iphoneで撮影した3024 x 4032の画像の場合)

close #63 