### PR TITLE
検定情報のfetch後にtopにスクロールする処理を追加

### DIFF
--- a/app/javascript/store/modules/exams.js
+++ b/app/javascript/store/modules/exams.js
@@ -35,12 +35,18 @@ export default {
   actions: {
     fetchExams({commit}){
       axios.get('/api/exams')
-        .then(res => commit('setExams', res.data))
+        .then(res => {
+          commit('setExams', res.data)
+          window.scrollTo(0,0)
+        })
         .catch(err => console.log(err.response))
     },
     fetchExam({commit}, exam_id){
       axios.get(`/api/exams/${exam_id}`)
-        .then(res => commit('setExam', res.data.exam))
+        .then(res =>  {
+          commit('setExam', res.data.exam)
+          window.scrollTo(0,0)
+        })
         .catch(err => console.log(err.response))
     }
   }


### PR DESCRIPTION
## 概要
- #151 を修正
- 検定情報のfetch後にtopにスクロールする処理を追加

## コメント
検定情報の表示 → トップへのスクロールの順で行われるため、
若干不自然な挙動ではある。暫定的な対応。

close #151 