### PR TITLE
検定結果ページでOGP画像を動的に設定する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'jbuilder', '~> 2.7'
 # gem 'bcrypt', '~> 3.1.7'
 
 # Use Active Storage variant
-# gem 'image_processing', '~> 1.2'
+gem 'image_processing', '~> 1.2'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,9 @@ GEM
       activesupport (>= 5.0)
     i18n (1.8.11)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.2)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.11.3)
       activesupport (>= 5.0.0)
     jmespath (1.4.0)
@@ -137,6 +140,7 @@ GEM
     meta-tags (2.16.0)
       actionpack (>= 3.2.0, < 7.1)
     method_source (1.0.0)
+    mini_magick (4.11.0)
     mini_mime (1.1.2)
     minitest (5.14.4)
     msgpack (1.4.2)
@@ -312,6 +316,7 @@ DEPENDENCIES
   byebug
   capybara
   factory_bot_rails
+  image_processing (~> 1.2)
   jbuilder (~> 2.7)
   listen (~> 3.3)
   meta-tags

--- a/app/controllers/exam_result_shares_controller.rb
+++ b/app/controllers/exam_result_shares_controller.rb
@@ -1,0 +1,5 @@
+class ExamResultSharesController < ApplicationController
+  def show
+    @exam_result = ExamResult.find(params[:exam_result_id])
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,4 +20,8 @@ module ApplicationHelper
       }
     }
   end
+
+  def request_url
+    "#{request.protocol}#{request.host}:#{request.port}"
+  end
 end

--- a/app/javascript/pages/ExamResult.vue
+++ b/app/javascript/pages/ExamResult.vue
@@ -203,8 +203,8 @@ export default {
       return this.exam_result.exam_result_comment.content.replaceAll('\\n', '\n')
     },
     twitterShare(){
-      const url = `${location.origin}/exam_results/${this.exam_result.id}.` // 末尾の.でツイート中のurl表示が省略されることを避ける
-      const text = `%0a%23ジョジョ立ち検定 を受検しました！%0a%0a検定名: ${this.exam_result.exam.title}検定%0a受験結果: ${this.resultText}%0a%0a▼ 受検結果ページ ▼%0a`
+      const url = `${location.origin}/exam_results/${this.exam_result.id}`
+      const text = `%23ジョジョ立ち検定 を受検しました！%0a%0a検定名: ${this.exam_result.exam.title}検定%0a受験結果: ${this.resultText}%0a%0a`
 
       return `https://twitter.com/intent/tweet?url=${url}&text=${text}`
     }

--- a/app/javascript/pages/Top.vue
+++ b/app/javascript/pages/Top.vue
@@ -70,13 +70,12 @@
         lg="5"
         xl="4"
       >
-      <a 
-        class="twitter-timeline"
-        href="https://twitter.com/jojo_pose_exam?ref_src=twsrc%5Etfw"
-        data-chrome="noheader nofooter"
-        height="800"
-      >
-      </a>
+        <a 
+          class="twitter-timeline"
+          href="https://twitter.com/jojo_pose_exam?ref_src=twsrc%5Etfw"
+          data-chrome="noheader nofooter"
+          height="800"
+        />
       </v-col>
     </v-row>
 
@@ -91,9 +90,6 @@
 <script>
 
 export default {
-  mounted(){
-    this.getTwitterTimelineScript()
-  },
   data: function () {
     return {
       logo_top_src: require('../../assets/images/logo_top.svg'),
@@ -116,6 +112,9 @@ export default {
         }
       ]
     }
+  },
+  mounted(){
+    this.getTwitterTimelineScript()
   },
   methods: {
     getTwitterTimelineScript(){

--- a/app/models/exam_result.rb
+++ b/app/models/exam_result.rb
@@ -132,9 +132,9 @@ class ExamResult < ApplicationRecord
 
   def pass_or_fail_text
     if self.total_score >= 80
-      '合格ッ！!'
+      '合格ッ！！'
     else
-      '不合格！'
+      '不合格！！'
     end
 
   end

--- a/app/models/exam_result.rb
+++ b/app/models/exam_result.rb
@@ -130,6 +130,15 @@ class ExamResult < ApplicationRecord
     score
   end
 
+  def pass_or_fail_text
+    if self.total_score >= 80
+      '合格ッ！!'
+    else
+      '不合格！'
+    end
+
+  end
+
   def delete_tmp_image
     return unless @upload_image_name
 

--- a/app/views/exam_result_shares/show.html.erb
+++ b/app/views/exam_result_shares/show.html.erb
@@ -1,0 +1,10 @@
+<% 
+  set_meta_tags(
+    og: { 
+      title: "#{@exam_result.exam.title}の受検結果",
+      description: "受検結果: #{@exam_result.total_score}点",
+      image: request_url + rails_storage_proxy_path(@exam_result.upload_image.variant(resize_and_pad: [1000, 500, {background: [255, 255, 255]}]).processed)
+    },
+    twitter: { card: 'summary_large_image' }
+  )
+%>

--- a/app/views/exam_result_shares/show.html.erb
+++ b/app/views/exam_result_shares/show.html.erb
@@ -1,8 +1,8 @@
 <% 
   set_meta_tags(
     og: { 
-      title: "#{@exam_result.exam.title}検定 #{@exam_result.total_score}点 #{@exam_result.pass_or_fail_text}",
-      description: @exam_result.exam_result_comment.content,
+      title: "#{@exam_result.exam.title}検定: #{@exam_result.pass_or_fail_text}",
+      description: @exam_result.exam_result_comment.content.gsub(/\\n/){''},
       image: request_url + rails_storage_proxy_path(@exam_result.upload_image.variant(resize_and_pad: [1000, 500, {background: [255, 255, 255]}]).processed)
     },
     twitter: { card: 'summary_large_image' }

--- a/app/views/exam_result_shares/show.html.erb
+++ b/app/views/exam_result_shares/show.html.erb
@@ -1,8 +1,8 @@
 <% 
   set_meta_tags(
     og: { 
-      title: "#{@exam_result.exam.title}の受検結果",
-      description: "受検結果: #{@exam_result.total_score}点",
+      title: "#{@exam_result.exam.title}検定 #{@exam_result.total_score}点 #{@exam_result.pass_or_fail_text}",
+      description: @exam_result.exam_result_comment.content,
       image: request_url + rails_storage_proxy_path(@exam_result.upload_image.variant(resize_and_pad: [1000, 500, {background: [255, 255, 255]}]).processed)
     },
     twitter: { card: 'summary_large_image' }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,9 @@ Rails.application.routes.draw do
     resources :exam_results, only: %i[create show]
   end
 
+	# 動的OGPのために、Twitterクローラーからのアクセス(=UserAgentにTwitterbotを含む)場合のルーティングを定義
+  get '/exam_results/:exam_result_id', to: 'exam_result_shares#show', constraints: { user_agent: /Twitterbot/ }
+
   get '*path', to: 'home#index', constraints: lambda { |req|
     # active_storageに保存したファイルを参照できるようにするために、
     # 'rails/active_storage'が含まれているurlはリダイレクト対象外にする

--- a/spec/requests/exam_result_shares_spec.rb
+++ b/spec/requests/exam_result_shares_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe "ExamResultShares", type: :request do
+  describe "GET /show" do
+    it "returns http success" do
+      get "/exam_result_shares/show"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/views/exam_result_shares/show.html.erb_spec.rb
+++ b/spec/views/exam_result_shares/show.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "exam_result_shares/show.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要
- 検定結果ページのTwiiter OGP画像を検定結果画像に変更
- 併せて、Twitterシェア時のデフォルト文も微修正
<img width="549" alt="image" src="https://user-images.githubusercontent.com/84756197/170711329-f7b9743e-5071-4eee-b2c7-f2f7ad22b8f0.png">


close #156